### PR TITLE
EIN-4586 changes related to trigger in core

### DIFF
--- a/src/main/java/no/einnsyn/apiv3/entities/journalpost/models/Journalpost.java
+++ b/src/main/java/no/einnsyn/apiv3/entities/journalpost/models/Journalpost.java
@@ -14,7 +14,9 @@ import jakarta.persistence.PreUpdate;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import no.einnsyn.apiv3.common.indexable.Indexable;
@@ -92,7 +94,7 @@ public class Journalpost extends Registrering implements Indexable {
   @ManyToMany(
       fetch = FetchType.LAZY,
       cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.DETACH})
-  private List<Dokumentbeskrivelse> dokumentbeskrivelse;
+  private Set<Dokumentbeskrivelse> dokumentbeskrivelse;
 
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "saksmappe_id", referencedColumnName = "saksmappe_id")
@@ -126,9 +128,16 @@ public class Journalpost extends Registrering implements Indexable {
    */
   public void addDokumentbeskrivelse(Dokumentbeskrivelse db) {
     if (dokumentbeskrivelse == null) {
-      dokumentbeskrivelse = new ArrayList<>();
+      dokumentbeskrivelse = new HashSet<>();
     }
     dokumentbeskrivelse.add(db);
+  }
+
+  public void removeDokumentbeskrivelseById(String dokumentbeskrivelseId) {
+    if (this.dokumentbeskrivelse == null) {
+      return;
+    }
+    this.dokumentbeskrivelse.removeIf(dbDokbesk -> dbDokbesk.getId().equals(dokumentbeskrivelseId));
   }
 
   /** Populate legacy (and other) required fields before saving to database. */

--- a/src/main/java/no/einnsyn/apiv3/entities/moetedokument/MoetedokumentService.java
+++ b/src/main/java/no/einnsyn/apiv3/entities/moetedokument/MoetedokumentService.java
@@ -6,6 +6,7 @@ import no.einnsyn.apiv3.common.exceptions.EInnsynException;
 import no.einnsyn.apiv3.common.paginators.Paginators;
 import no.einnsyn.apiv3.common.resultlist.ResultList;
 import no.einnsyn.apiv3.entities.base.models.BaseListQueryDTO;
+import no.einnsyn.apiv3.entities.dokumentbeskrivelse.models.Dokumentbeskrivelse;
 import no.einnsyn.apiv3.entities.dokumentbeskrivelse.models.DokumentbeskrivelseDTO;
 import no.einnsyn.apiv3.entities.dokumentbeskrivelse.models.DokumentbeskrivelseListQueryDTO;
 import no.einnsyn.apiv3.entities.moetedokument.models.Moetedokument;
@@ -163,9 +164,9 @@ public class MoetedokumentService extends RegistreringService<Moetedokument, Moe
     // Dokumentbeskrivelse
     var dokumentbeskrivelseList = moetedokument.getDokumentbeskrivelse();
     if (dokumentbeskrivelseList != null) {
-      moetedokument.setDokumentbeskrivelse(null);
-      for (var dokumentbeskrivelse : dokumentbeskrivelseList) {
-        dokumentbeskrivelseService.deleteIfOrphan(dokumentbeskrivelse);
+      var ids = dokumentbeskrivelseList.stream().map(Dokumentbeskrivelse::getId).toList();
+      for (var dokbesk : ids) {
+        moetedokument.removeDokumentbeskrivelseById(dokbesk);
       }
     }
 

--- a/src/main/java/no/einnsyn/apiv3/entities/moetedokument/models/Moetedokument.java
+++ b/src/main/java/no/einnsyn/apiv3/entities/moetedokument/models/Moetedokument.java
@@ -11,7 +11,9 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import no.einnsyn.apiv3.entities.dokumentbeskrivelse.models.Dokumentbeskrivelse;
@@ -76,12 +78,19 @@ public class Moetedokument extends Registrering {
       })
   @ManyToMany(
       cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.DETACH})
-  private List<Dokumentbeskrivelse> dokumentbeskrivelse;
+  private Set<Dokumentbeskrivelse> dokumentbeskrivelse;
 
   public void addDokumentbeskrivelse(Dokumentbeskrivelse dokumentbeskrivelse) {
     if (this.dokumentbeskrivelse == null) {
-      this.dokumentbeskrivelse = new ArrayList<>();
+      this.dokumentbeskrivelse = new HashSet<>();
     }
     this.dokumentbeskrivelse.add(dokumentbeskrivelse);
+  }
+
+  public void removeDokumentbeskrivelseById(String dokumentbeskrivelseId) {
+    if (this.dokumentbeskrivelse == null) {
+      return;
+    }
+    this.dokumentbeskrivelse.removeIf(dokbesk -> dokbesk.getId().equals(dokumentbeskrivelseId));
   }
 }

--- a/src/main/java/no/einnsyn/apiv3/entities/moetesak/MoetesakService.java
+++ b/src/main/java/no/einnsyn/apiv3/entities/moetesak/MoetesakService.java
@@ -7,6 +7,7 @@ import no.einnsyn.apiv3.common.exceptions.EInnsynException;
 import no.einnsyn.apiv3.common.paginators.Paginators;
 import no.einnsyn.apiv3.common.resultlist.ResultList;
 import no.einnsyn.apiv3.entities.base.models.BaseListQueryDTO;
+import no.einnsyn.apiv3.entities.dokumentbeskrivelse.models.Dokumentbeskrivelse;
 import no.einnsyn.apiv3.entities.dokumentbeskrivelse.models.DokumentbeskrivelseDTO;
 import no.einnsyn.apiv3.entities.dokumentbeskrivelse.models.DokumentbeskrivelseListQueryDTO;
 import no.einnsyn.apiv3.entities.moetesak.models.Moetesak;
@@ -251,9 +252,9 @@ public class MoetesakService extends RegistreringService<Moetesak, MoetesakDTO> 
     // Delete all dokumentbeskrivelses
     var dokumentbeskrivelseList = moetesak.getDokumentbeskrivelse();
     if (dokumentbeskrivelseList != null) {
-      moetesak.setDokumentbeskrivelse(null);
-      for (var dokumentbeskrivelse : dokumentbeskrivelseList) {
-        dokumentbeskrivelseService.deleteIfOrphan(dokumentbeskrivelse);
+      var ids = dokumentbeskrivelseList.stream().map(Dokumentbeskrivelse::getId).toList();
+      for (var dokbesk : ids) {
+        moetesak.removeDokumentbeskrivelseById(dokbesk);
       }
     }
 

--- a/src/main/java/no/einnsyn/apiv3/entities/moetesak/models/Moetesak.java
+++ b/src/main/java/no/einnsyn/apiv3/entities/moetesak/models/Moetesak.java
@@ -11,8 +11,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import no.einnsyn.apiv3.common.indexable.Indexable;
@@ -96,12 +96,19 @@ public class Moetesak extends Registrering implements Indexable {
             referencedColumnName = "dokumentbeskrivelse_id")
       })
   @ManyToMany
-  private List<Dokumentbeskrivelse> dokumentbeskrivelse;
+  private Set<Dokumentbeskrivelse> dokumentbeskrivelse;
 
   public void addDokumentbeskrivelse(Dokumentbeskrivelse dokumentbeskrivelse) {
     if (this.dokumentbeskrivelse == null) {
-      this.dokumentbeskrivelse = new ArrayList<>();
+      this.dokumentbeskrivelse = new HashSet<>();
     }
     this.dokumentbeskrivelse.add(dokumentbeskrivelse);
+  }
+
+  public void removeDokumentbeskrivelseById(String dokumentbeskrivelseId) {
+    if (this.dokumentbeskrivelse == null) {
+      return;
+    }
+    this.dokumentbeskrivelse.removeIf(dokbesk -> dokbesk.getId().equals(dokumentbeskrivelseId));
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,7 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+    out-of-order: true
   # security:
   #   oauth2:
   #     client:

--- a/src/main/resources/db/migration/V20240110_1500__Multiple_enhetskoder_virksomhet.sql
+++ b/src/main/resources/db/migration/V20240110_1500__Multiple_enhetskoder_virksomhet.sql
@@ -1,0 +1,1 @@
+ALTER TABLE IF EXISTS enhet ALTER COLUMN enhets_kode TYPE text;

--- a/src/main/resources/db/migration/V20240213_1337__delete_trigger_orphan_dokbesk.sql
+++ b/src/main/resources/db/migration/V20240213_1337__delete_trigger_orphan_dokbesk.sql
@@ -1,0 +1,36 @@
+CREATE OR REPLACE FUNCTION process_dokbeskrivelse() RETURNS TRIGGER AS
+$body$
+BEGIN
+    IF (TG_OP = 'DELETE') THEN
+        delete from dokumentbeskrivelse dbe
+        where dbe.dokumentbeskrivelse_id = OLD.dokumentbeskrivelse_id
+          and not exists (select 1 from journalpost_dokumentbeskrivelse jdb
+                          where jdb.dokumentbeskrivelse_id = OLD.dokumentbeskrivelse_id)
+          and not exists (select 1 from møtesaksregistrering_dokumentbeskrivelse mdb
+                          where mdb.dokumentbeskrivelse_id = OLD.dokumentbeskrivelse_id)
+          and not exists (select 1 from møtedokumentregistrering_dokumentbeskrivelse mmdb
+                          where mmdb.dokumentbeskrivelse_id = OLD.dokumentbeskrivelse_id)
+          and not exists (select 1 from utredning_utredningsdokument uut
+                          where uut.utredningsdokument__id = dbe._id)
+          and not exists (select 1 from vedtak_vedtaksdokument vve
+                           where vve.vedtaksdokument__id = dbe._id);
+    END IF;
+    RETURN null;
+END;
+$body$
+LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS delete_orphan_dokbesk_jp ON journalpost_dokumentbeskrivelse;
+CREATE TRIGGER delete_orphan_dokbesk_jp
+    AFTER DELETE ON journalpost_dokumentbeskrivelse
+    FOR EACH ROW EXECUTE FUNCTION process_dokbeskrivelse();
+
+DROP TRIGGER IF EXISTS delete_orphan_dokbesk_ms ON møtesaksregistrering_dokumentbeskrivelse;
+CREATE TRIGGER delete_orphan_dokbesk_ms
+    AFTER DELETE ON møtesaksregistrering_dokumentbeskrivelse
+    FOR EACH ROW EXECUTE FUNCTION process_dokbeskrivelse();
+
+DROP TRIGGER IF EXISTS delete_orphan_dokbesk_md ON møtedokumentregistrering_dokumentbeskrivelse;
+CREATE TRIGGER delete_orphan_dokbesk_md
+    AFTER DELETE ON møtedokumentregistrering_dokumentbeskrivelse
+    FOR EACH ROW EXECUTE FUNCTION process_dokbeskrivelse();

--- a/src/main/resources/db/migration/V20240223_0900__index_dokumentbeskrivelse_id.sql
+++ b/src/main/resources/db/migration/V20240223_0900__index_dokumentbeskrivelse_id.sql
@@ -1,0 +1,8 @@
+CREATE INDEX IF NOT EXISTS journalpost_dokbesk_dok_id_idx
+    ON journalpost_dokumentbeskrivelse (dokumentbeskrivelse_id);
+
+CREATE INDEX IF NOT EXISTS moetesak_dokbesk_dok_id_idx
+    ON møtesaksregistrering_dokumentbeskrivelse (dokumentbeskrivelse_id);
+
+CREATE INDEX IF NOT EXISTS moetedok_dokbesk_dok_id_idx
+    ON møtedokumentregistrering_dokumentbeskrivelse (dokumentbeskrivelse_id);


### PR DESCRIPTION
Et par av endringene kommer fra [Thorben Janssen](https://thorben-janssen.com/hibernate-tips-the-best-way-to-remove-entities-from-a-many-to-many-association/).
Det ble forsøkt å bruke deleteIfOrphan sammen med funksjonaliteten som ligger i triggeren, men det førte alltid til et kappløp mellom transaksjon i databasen og transaksjon i hibernate.

Triggeren er fremdeles på de tre tabellene fra core, men er justert til å ikke slette dokumentbeskrivelser hvis de også fins i utredning/vedtak.