### PR TITLE
EIN-X: Specify order on all OneToMany / ManyToMany relations

### DIFF
--- a/src/main/java/no/einnsyn/backend/entities/bruker/models/Bruker.java
+++ b/src/main/java/no/einnsyn/backend/entities/bruker/models/Bruker.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
@@ -67,6 +68,7 @@ public class Bruker extends Base {
       fetch = FetchType.LAZY,
       mappedBy = "bruker",
       cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.DETACH})
+  @OrderBy("id ASC")
   private List<InnsynskravBestilling> innsynskravBestilling;
 
   // @OneToMany(fetch = FetchType.LAZY, mappedBy = "bruker", cascade = {CascadeType.MERGE,

--- a/src/main/java/no/einnsyn/backend/entities/dokumentbeskrivelse/models/Dokumentbeskrivelse.java
+++ b/src/main/java/no/einnsyn/backend/entities/dokumentbeskrivelse/models/Dokumentbeskrivelse.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.PrePersist;
 import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ public class Dokumentbeskrivelse extends ArkivBase {
       fetch = FetchType.EAGER,
       mappedBy = "dokumentbeskrivelse",
       cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.DETACH})
+  @OrderBy("id ASC")
   private List<Dokumentobjekt> dokumentobjekt;
 
   public void addDokumentobjekt(Dokumentobjekt dobj) {

--- a/src/main/java/no/einnsyn/backend/entities/enhet/models/Enhet.java
+++ b/src/main/java/no/einnsyn/backend/entities/enhet/models/Enhet.java
@@ -9,6 +9,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.validation.constraints.Email;
@@ -57,6 +58,7 @@ public class Enhet extends Base {
       fetch = FetchType.LAZY,
       mappedBy = "parent",
       cascade = {CascadeType.ALL})
+  @OrderBy("id ASC")
   private List<Enhet> underenhet;
 
   private boolean skjult;

--- a/src/main/java/no/einnsyn/backend/entities/lagretsoek/models/LagretSoek.java
+++ b/src/main/java/no/einnsyn/backend/entities/lagretsoek/models/LagretSoek.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -43,6 +44,7 @@ public class LagretSoek extends Base implements Indexable {
       mappedBy = "lagretSoek",
       cascade = {CascadeType.ALL},
       orphanRemoval = true)
+  @OrderBy("id ASC")
   private List<LagretSoekHit> hitList;
 
   @Column(name = "search_parameters")

--- a/src/main/java/no/einnsyn/backend/entities/moetedokument/models/Moetedokument.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetedokument/models/Moetedokument.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -55,6 +56,7 @@ public class Moetedokument extends Registrering {
       fetch = FetchType.LAZY,
       mappedBy = "parentMoetedokument",
       cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.DETACH})
+  @OrderBy("id ASC")
   private List<Korrespondansepart> korrespondansepart;
 
   public void addKorrespondansepart(Korrespondansepart korrespondansepart) {
@@ -81,6 +83,7 @@ public class Moetedokument extends Registrering {
       })
   @ManyToMany(
       cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.DETACH})
+  @OrderBy("id ASC")
   private List<Dokumentbeskrivelse> dokumentbeskrivelse;
 
   public void addDokumentbeskrivelse(Dokumentbeskrivelse dokumentbeskrivelse) {

--- a/src/main/java/no/einnsyn/backend/entities/moetemappe/models/Moetemappe.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetemappe/models/Moetemappe.java
@@ -8,6 +8,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -62,6 +63,7 @@ public class Moetemappe extends Mappe implements Indexable {
       mappedBy = "moetemappe")
   @Filter(name = "accessibleOrAdminFilter")
   @Filter(name = "accessibleFilter")
+  @OrderBy("id ASC")
   private List<Moetesak> moetesak;
 
   @OneToMany(
@@ -70,6 +72,7 @@ public class Moetemappe extends Mappe implements Indexable {
       mappedBy = "moetemappe")
   @Filter(name = "accessibleOrAdminFilter")
   @Filter(name = "accessibleFilter")
+  @OrderBy("id ASC")
   private List<Moetedokument> moetedokument;
 
   // lastIndexed should not be updated through JPA

--- a/src/main/java/no/einnsyn/backend/entities/moetesak/models/Moetesak.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetesak/models/Moetesak.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
@@ -113,6 +114,7 @@ public class Moetesak extends Registrering implements Indexable {
             referencedColumnName = "dokumentbeskrivelse_id")
       })
   @ManyToMany
+  @OrderBy("id ASC")
   private List<Dokumentbeskrivelse> dokumentbeskrivelse;
 
   public void addDokumentbeskrivelse(Dokumentbeskrivelse dokumentbeskrivelse) {

--- a/src/main/java/no/einnsyn/backend/entities/saksmappe/models/Saksmappe.java
+++ b/src/main/java/no/einnsyn/backend/entities/saksmappe/models/Saksmappe.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
 import java.time.Instant;
@@ -44,6 +45,7 @@ public class Saksmappe extends Mappe implements Indexable {
       mappedBy = "saksmappe")
   @Filter(name = "accessibleOrAdminFilter")
   @Filter(name = "accessibleFilter")
+  @OrderBy("id ASC")
   private List<Journalpost> journalpost;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/no/einnsyn/backend/entities/utredning/models/Utredning.java
+++ b/src/main/java/no/einnsyn/backend/entities/utredning/models/Utredning.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.OrderBy;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -33,6 +34,7 @@ public class Utredning extends ArkivBase {
   @JoinTable(name = "utredning_utredningsdokument")
   @ManyToMany(
       cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.DETACH})
+  @OrderBy("id ASC")
   private List<Dokumentbeskrivelse> utredningsdokument;
 
   public void addUtredningsdokument(Dokumentbeskrivelse dokumentbeskrivelse) {

--- a/src/main/java/no/einnsyn/backend/entities/vedtak/models/Vedtak.java
+++ b/src/main/java/no/einnsyn/backend/entities/vedtak/models/Vedtak.java
@@ -7,6 +7,7 @@ import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.OrderBy;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,12 +38,14 @@ public class Vedtak extends ArkivBase {
       fetch = FetchType.LAZY,
       cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.DETACH},
       mappedBy = "vedtak")
+  @OrderBy("id ASC")
   private List<Votering> votering;
 
   @JoinTable(name = "vedtak_vedtaksdokument")
   @ManyToMany(
       fetch = FetchType.LAZY,
       cascade = {CascadeType.MERGE, CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.DETACH})
+  @OrderBy("id ASC")
   private List<Dokumentbeskrivelse> vedtaksdokument;
 
   private LocalDate dato;


### PR DESCRIPTION
By default, the order of collections isn't guaranteed. Make it consistent by specifying OrderBy("id").