### PR TITLE
EIN-4807: Add fulltext-flag to ES

### DIFF
--- a/src/main/java/no/einnsyn/backend/entities/journalpost/JournalpostService.java
+++ b/src/main/java/no/einnsyn/backend/entities/journalpost/JournalpostService.java
@@ -345,7 +345,9 @@ public class JournalpostService extends RegistreringService<Journalpost, Journal
       }
 
       // Dokumentbeskrivelses
+      journalpostES.setFulltext(false);
       var dokumentbeskrivelseList = journalpost.getDokumentbeskrivelse();
+
       if (dokumentbeskrivelseList != null) {
         var dokumentbeskrivelseES =
             dokumentbeskrivelseList.stream()
@@ -357,14 +359,15 @@ public class JournalpostService extends RegistreringService<Journalpost, Journal
                 .toList();
         journalpostES.setDokumentbeskrivelse(dokumentbeskrivelseES);
         for (var dokument : dokumentbeskrivelseES) {
-          // ReferanseDokumentfil is mandatory for dokumentobjekt.
+          // A dokumentobjekt must have a link to a fulltext file, so we can safely mark the
+          // journalpost if at least one dokumentobjekt is present.
           if (dokument.getDokumentobjekt() != null && !dokument.getDokumentobjekt().isEmpty()) {
             journalpostES.setFulltext(true);
+            break;
           }
         }
       } else {
         journalpostES.setDokumentbeskrivelse(List.of());
-        journalpostES.setFulltext(false);
       }
 
       // StandardDato

--- a/src/main/java/no/einnsyn/backend/entities/journalpost/JournalpostService.java
+++ b/src/main/java/no/einnsyn/backend/entities/journalpost/JournalpostService.java
@@ -356,8 +356,15 @@ public class JournalpostService extends RegistreringService<Journalpost, Journal
                                 dokumentbeskrivelse, new DokumentbeskrivelseES()))
                 .toList();
         journalpostES.setDokumentbeskrivelse(dokumentbeskrivelseES);
+        for (var dokument : dokumentbeskrivelseES) {
+          // ReferanseDokumentfil is mandatory for dokumentobjekt.
+          if (dokument.getDokumentobjekt() != null && !dokument.getDokumentobjekt().isEmpty()) {
+              journalpostES.setFulltext(true);
+          }
+        }
       } else {
         journalpostES.setDokumentbeskrivelse(List.of());
+        journalpostES.setFulltext(false);
       }
 
       // StandardDato

--- a/src/main/java/no/einnsyn/backend/entities/journalpost/JournalpostService.java
+++ b/src/main/java/no/einnsyn/backend/entities/journalpost/JournalpostService.java
@@ -359,7 +359,7 @@ public class JournalpostService extends RegistreringService<Journalpost, Journal
         for (var dokument : dokumentbeskrivelseES) {
           // ReferanseDokumentfil is mandatory for dokumentobjekt.
           if (dokument.getDokumentobjekt() != null && !dokument.getDokumentobjekt().isEmpty()) {
-              journalpostES.setFulltext(true);
+            journalpostES.setFulltext(true);
           }
         }
       } else {

--- a/src/main/java/no/einnsyn/backend/entities/moetedokument/MoetedokumentService.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetedokument/MoetedokumentService.java
@@ -147,16 +147,24 @@ public class MoetedokumentService extends RegistreringService<Moetedokument, Moe
 
       var dokumentbeskrivelseList = moetedokument.getDokumentbeskrivelse();
       if (dokumentbeskrivelseList != null) {
-        moetedokumentES.setDokumentbeskrivelse(
+        var dokumentbeskrivelseES =
             dokumentbeskrivelseList.stream()
                 .map(
                     dokumentbeskrivelse ->
                         (DokumentbeskrivelseES)
                             dokumentbeskrivelseService.toLegacyES(
                                 dokumentbeskrivelse, new DokumentbeskrivelseES()))
-                .toList());
+                .toList();
+        moetedokumentES.setDokumentbeskrivelse(dokumentbeskrivelseES);
+        for (var dokument : dokumentbeskrivelseES) {
+          // ReferanseDokumentfil is mandatory for dokumentobjekt.
+          if (dokument.getDokumentobjekt() != null && !dokument.getDokumentobjekt().isEmpty()) {
+            moetedokumentES.setFulltext(true);
+          }
+        }
       } else {
         moetedokumentES.setDokumentbeskrivelse(List.of());
+        moetedokumentES.setFulltext(false);
       }
     }
     return es;

--- a/src/main/java/no/einnsyn/backend/entities/moetedokument/MoetedokumentService.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetedokument/MoetedokumentService.java
@@ -145,6 +145,7 @@ public class MoetedokumentService extends RegistreringService<Moetedokument, Moe
       moetedokumentES.setMøtedokumentregistreringstype(
           moetedokument.getMoetedokumentregistreringstype());
 
+      moetedokumentES.setFulltext(false);
       var dokumentbeskrivelseList = moetedokument.getDokumentbeskrivelse();
       if (dokumentbeskrivelseList != null) {
         var dokumentbeskrivelseES =
@@ -157,14 +158,15 @@ public class MoetedokumentService extends RegistreringService<Moetedokument, Moe
                 .toList();
         moetedokumentES.setDokumentbeskrivelse(dokumentbeskrivelseES);
         for (var dokument : dokumentbeskrivelseES) {
-          // ReferanseDokumentfil is mandatory for dokumentobjekt.
+          // A dokumentobjekt must have a link to a fulltext file, so we can safely mark the
+          // moetedokument if at least one dokumentobjekt is present.
           if (dokument.getDokumentobjekt() != null && !dokument.getDokumentobjekt().isEmpty()) {
             moetedokumentES.setFulltext(true);
+            break;
           }
         }
       } else {
         moetedokumentES.setDokumentbeskrivelse(List.of());
-        moetedokumentES.setFulltext(false);
       }
     }
     return es;

--- a/src/main/java/no/einnsyn/backend/entities/moetesak/MoetesakService.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetesak/MoetesakService.java
@@ -320,6 +320,7 @@ public class MoetesakService extends RegistreringService<Moetesak, MoetesakDTO> 
       // ReferanseTilMoetesak TODO? Is this set in the old import?
 
       // Dokumentbeskrivelses
+      moetesakES.setFulltext(false);
       var dokumentbeskrivelse = moetesak.getDokumentbeskrivelse();
       if (dokumentbeskrivelse != null) {
         var dokumentbeskrivelseES =
@@ -331,14 +332,14 @@ public class MoetesakService extends RegistreringService<Moetesak, MoetesakDTO> 
                 .toList();
         moetesakES.setDokumentbeskrivelse(dokumentbeskrivelseES);
         for (var dokument : dokumentbeskrivelseES) {
-          // ReferanseDokumentfil is mandatory for dokumentobjekt.
+          // A dokumentobjekt must have a link to a fulltext file, so we can safely mark the
+          // moetesak if at least one dokumentobjekt is present.
           if (dokument.getDokumentobjekt() != null && !dokument.getDokumentobjekt().isEmpty()) {
             moetesakES.setFulltext(true);
           }
         }
       } else {
         moetesakES.setDokumentbeskrivelse(List.of());
-        moetesakES.setFulltext(false);
       }
     }
 

--- a/src/main/java/no/einnsyn/backend/entities/moetesak/MoetesakService.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetesak/MoetesakService.java
@@ -330,6 +330,15 @@ public class MoetesakService extends RegistreringService<Moetesak, MoetesakDTO> 
                             dokumentbeskrivelseService.toLegacyES(d, new DokumentbeskrivelseES()))
                 .toList();
         moetesakES.setDokumentbeskrivelse(dokumentbeskrivelseES);
+        for (var dokument : dokumentbeskrivelseES) {
+          // ReferanseDokumentfil is mandatory for dokumentobjekt.
+          if (dokument.getDokumentobjekt() != null && !dokument.getDokumentobjekt().isEmpty()) {
+            moetesakES.setFulltext(true);
+          }
+        }
+      } else {
+        moetesakES.setDokumentbeskrivelse(List.of());
+        moetesakES.setFulltext(false);
       }
     }
 

--- a/src/main/java/no/einnsyn/backend/entities/registrering/models/RegistreringES.java
+++ b/src/main/java/no/einnsyn/backend/entities/registrering/models/RegistreringES.java
@@ -17,4 +17,5 @@ public class RegistreringES extends ArkivBaseES {
   private String offentligTittel_SENSITIV;
 
   private String sorteringstype = "";
+  private boolean fulltext = false;
 }

--- a/src/main/resources/elasticsearch/indexMappings.json
+++ b/src/main/resources/elasticsearch/indexMappings.json
@@ -34,6 +34,9 @@
     "created": {
       "type": "date"
     },
+    "fulltext": {
+      "type": "boolean"
+    },
     "dokumentbeskrivelse": {
       "properties": {
         "tittel": {

--- a/src/test/java/no/einnsyn/backend/entities/moetesak/MoetesakLegacyESTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/moetesak/MoetesakLegacyESTest.java
@@ -1,6 +1,8 @@
 package no.einnsyn.backend.entities.moetesak;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,6 +15,7 @@ import no.einnsyn.backend.entities.moetemappe.models.MoetemappeDTO;
 import no.einnsyn.backend.entities.moetemappe.models.MoetemappeES;
 import no.einnsyn.backend.entities.moetesak.models.MoetesakDTO;
 import no.einnsyn.backend.entities.moetesak.models.MoetesakES;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -183,5 +186,53 @@ class MoetesakLegacyESTest extends EinnsynLegacyElasticTestBase {
     // Should have deleted one Moetesak
     var deletedDocuments = captureDeletedDocuments(1);
     assertTrue(deletedDocuments.contains(moetesakDTO.getId()));
+  }
+
+  @Test
+  void markMoetesakWithFulltextDocumentsAsSuch() throws Exception {
+    // Create moetesak with dokumentbeskrivelse and dokumentobjekt
+    var moetesak1JSON = getMoetesakJSON();
+    moetesak1JSON.put("offentligTittel", "Moetesak with fulltext");
+    var dokumentbeskrivelseJSON = getDokumentbeskrivelseJSON();
+    dokumentbeskrivelseJSON.put("dokumentobjekt", new JSONArray(List.of(getDokumentobjektJSON())));
+    moetesak1JSON.put("dokumentbeskrivelse", new JSONArray(List.of(dokumentbeskrivelseJSON)));
+
+    var response = post("/moetemappe/" + moetemappeDTO.getId() + "/moetesak", moetesak1JSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var moetesak1DTO = gson.fromJson(response.getBody(), MoetesakDTO.class);
+
+    var documentMap = captureIndexedDocuments(2);
+    resetEs();
+    assertNotNull(documentMap.get(moetemappeDTO.getId()));
+    assertNotNull(documentMap.get(moetesak1DTO.getId()));
+
+    // The moetesak should be marked as fulltext
+    var journalpost1ES = (MoetesakES) documentMap.get(moetesak1DTO.getId());
+    assertTrue(journalpost1ES.isFulltext());
+
+    // Create moetesak without dokumentbeskrivelse
+    var moetesak2JSON = getMoetesakJSON();
+    response = post("/moetemappe/" + moetemappeDTO.getId() + "/moetesak", moetesak2JSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+
+    var moetesak2DTO = gson.fromJson(response.getBody(), MoetesakDTO.class);
+    documentMap = captureIndexedDocuments(2);
+    resetEs();
+    assertNotNull(documentMap.get(moetemappeDTO.getId()));
+    assertNotNull(documentMap.get(moetesak2DTO.getId()));
+
+    // The moetesak should not be marked as fulltext
+    var journalpost2ES = (MoetesakES) documentMap.get(moetesak2DTO.getId());
+    assertFalse(journalpost2ES.isFulltext());
+
+    // Cleanup
+    response = delete("/moetesak/" + moetesak1DTO.getId());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNull(moetesakRepository.findById(moetesak1DTO.getId()).orElse(null));
+
+    response = delete("/moetesak/" + moetesak2DTO.getId());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertNull(moetesakRepository.findById(moetesak2DTO.getId()).orElse(null));
+    captureDeletedDocuments(2);
   }
 }


### PR DESCRIPTION
Marks Journalpost, Moetesak and Moetedokument with a flag to indicate the presence of fulltext documents during indexing.