### PR TITLE
EIN-Stream-Refactor: Only return IDs when we don't need entire objects

### DIFF
--- a/src/main/java/no/einnsyn/backend/entities/apikey/ApiKeyRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/apikey/ApiKeyRepository.java
@@ -28,7 +28,8 @@ public interface ApiKeyRepository extends BaseRepository<ApiKey> {
       """)
   Slice<ApiKey> paginateDesc(Enhet enhet, String pivot, Pageable pageable);
 
-  Stream<ApiKey> findAllByEnhet(Enhet enhet);
+  @Query("SELECT o.id FROM ApiKey o WHERE enhet = :enhet")
+  Stream<String> findIdsByEnhet(Enhet enhet);
 
   ApiKey findBySecret(String hashedSecret);
 }

--- a/src/main/java/no/einnsyn/backend/entities/arkiv/ArkivRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/arkiv/ArkivRepository.java
@@ -45,5 +45,6 @@ public interface ArkivRepository extends ArkivBaseRepository<Arkiv> {
       """)
   Slice<Arkiv> paginateDesc(Enhet enhet, String pivot, Pageable pageable);
 
-  Stream<Arkiv> findAllByParent(Arkiv parent);
+  @Query("SELECT o.id FROM Arkiv o WHERE parent = :parent")
+  Stream<String> findIdsByParent(Arkiv parent);
 }

--- a/src/main/java/no/einnsyn/backend/entities/arkiv/ArkivService.java
+++ b/src/main/java/no/einnsyn/backend/entities/arkiv/ArkivService.java
@@ -134,35 +134,31 @@ public class ArkivService extends ArkivBaseService<Arkiv, ArkivDTO> {
    */
   @Override
   protected void deleteEntity(Arkiv arkiv) throws EInnsynException {
-    try (var subArkivStream = repository.findAllByParent(arkiv)) {
-      var subArkivIterator = subArkivStream.iterator();
-      while (subArkivIterator.hasNext()) {
-        var subArkiv = subArkivIterator.next();
-        arkivService.delete(subArkiv.getId());
+    try (var subArkivIdStream = repository.findIdsByParent(arkiv)) {
+      var subArkivIdIterator = subArkivIdStream.iterator();
+      while (subArkivIdIterator.hasNext()) {
+        arkivService.delete(subArkivIdIterator.next());
       }
     }
 
-    try (var arkivdelStream = arkivdelRepository.findAllByParent(arkiv)) {
-      var arkivdelIterator = arkivdelStream.iterator();
-      while (arkivdelIterator.hasNext()) {
-        var arkivdel = arkivdelIterator.next();
-        arkivdelService.delete(arkivdel.getId());
+    try (var arkivdelIdStream = arkivdelRepository.findIdsByParent(arkiv)) {
+      var arkivdelIdIterator = arkivdelIdStream.iterator();
+      while (arkivdelIdIterator.hasNext()) {
+        arkivdelService.delete(arkivdelIdIterator.next());
       }
     }
 
-    try (var subSaksmappeStream = saksmappeRepository.findAllByParentArkiv(arkiv)) {
-      var subSaksmappeIterator = subSaksmappeStream.iterator();
-      while (subSaksmappeIterator.hasNext()) {
-        var subSaksmappe = subSaksmappeIterator.next();
-        saksmappeService.delete(subSaksmappe.getId());
+    try (var subSaksmappeIdStream = saksmappeRepository.findIdsByParentArkiv(arkiv)) {
+      var subSaksmappeIdIterator = subSaksmappeIdStream.iterator();
+      while (subSaksmappeIdIterator.hasNext()) {
+        saksmappeService.delete(subSaksmappeIdIterator.next());
       }
     }
 
-    try (var subMoetemappeStream = moetemappeRepository.findAllByParentArkiv(arkiv)) {
-      var subMoetemappeIterator = subMoetemappeStream.iterator();
-      while (subMoetemappeIterator.hasNext()) {
-        var subMoetemappe = subMoetemappeIterator.next();
-        moetemappeService.delete(subMoetemappe.getId());
+    try (var subMoetemappeIdStream = moetemappeRepository.findIdsByParentArkiv(arkiv)) {
+      var subMoetemappeIdIterator = subMoetemappeIdStream.iterator();
+      while (subMoetemappeIdIterator.hasNext()) {
+        moetemappeService.delete(subMoetemappeIdIterator.next());
       }
     }
 

--- a/src/main/java/no/einnsyn/backend/entities/arkivdel/ArkivdelRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/arkivdel/ArkivdelRepository.java
@@ -27,5 +27,6 @@ public interface ArkivdelRepository extends ArkivBaseRepository<Arkivdel> {
       """)
   Slice<Arkivdel> paginateDesc(Arkiv arkiv, String pivot, Pageable pageable);
 
-  Stream<Arkivdel> findAllByParent(Arkiv parent);
+  @Query("SELECT o.id FROM Arkivdel o WHERE parent = :parent")
+  Stream<String> findIdsByParent(Arkiv parent);
 }

--- a/src/main/java/no/einnsyn/backend/entities/arkivdel/ArkivdelService.java
+++ b/src/main/java/no/einnsyn/backend/entities/arkivdel/ArkivdelService.java
@@ -137,36 +137,32 @@ public class ArkivdelService extends ArkivBaseService<Arkivdel, ArkivdelDTO> {
 
   @Override
   protected void deleteEntity(Arkivdel arkivdel) throws EInnsynException {
-    try (var saksmappeStream = saksmappeRepository.findAllByParentArkivdel(arkivdel)) {
-      var saksmappeIterator = saksmappeStream.iterator();
-      while (saksmappeIterator.hasNext()) {
-        var saksmappe = saksmappeIterator.next();
-        saksmappeService.delete(saksmappe.getId());
+    try (var saksmappeIdStream = saksmappeRepository.findIdsByParentArkivdel(arkivdel)) {
+      var saksmappeIdIterator = saksmappeIdStream.iterator();
+      while (saksmappeIdIterator.hasNext()) {
+        saksmappeService.delete(saksmappeIdIterator.next());
       }
     }
 
-    try (var moetemappeStream = moetemappeRepository.findAllByParentArkivdel(arkivdel)) {
-      var moetemappeIterator = moetemappeStream.iterator();
-      while (moetemappeIterator.hasNext()) {
-        var moetemappe = moetemappeIterator.next();
-        moetemappeService.delete(moetemappe.getId());
+    try (var moetemappeIdStream = moetemappeRepository.findIdsByParentArkivdel(arkivdel)) {
+      var moetemappeIdIterator = moetemappeIdStream.iterator();
+      while (moetemappeIdIterator.hasNext()) {
+        moetemappeService.delete(moetemappeIdIterator.next());
       }
     }
 
-    try (var klassifikasjonssystemStream =
-        klassifikasjonssystemRepository.findByArkivdel(arkivdel)) {
-      var klassifikasjonssystemIterator = klassifikasjonssystemStream.iterator();
-      while (klassifikasjonssystemIterator.hasNext()) {
-        var klassifikasjonssystem = klassifikasjonssystemIterator.next();
-        klassifikasjonssystemService.delete(klassifikasjonssystem.getId());
+    try (var klassifikasjonssystemIdStream =
+        klassifikasjonssystemRepository.findIdsByArkivdel(arkivdel)) {
+      var klassifikasjonssystemIdIterator = klassifikasjonssystemIdStream.iterator();
+      while (klassifikasjonssystemIdIterator.hasNext()) {
+        klassifikasjonssystemService.delete(klassifikasjonssystemIdIterator.next());
       }
     }
 
-    try (var klasseStream = klasseRepository.findAllByParentArkivdel(arkivdel)) {
-      var klasseIterator = klasseStream.iterator();
-      while (klasseIterator.hasNext()) {
-        var klasse = klasseIterator.next();
-        klasseService.delete(klasse.getId());
+    try (var klasseIdStream = klasseRepository.findIdsByParentArkivdel(arkivdel)) {
+      var klasseIdIterator = klasseIdStream.iterator();
+      while (klasseIdIterator.hasNext()) {
+        klasseService.delete(klasseIdIterator.next());
       }
     }
 

--- a/src/main/java/no/einnsyn/backend/entities/bruker/BrukerService.java
+++ b/src/main/java/no/einnsyn/backend/entities/bruker/BrukerService.java
@@ -355,20 +355,18 @@ public class BrukerService extends BaseService<Bruker, BrukerDTO> {
     }
 
     // Delete all LagretSak
-    try (var lagretSakStream = lagretSakRepository.findByBruker(bruker.getId())) {
-      var lagretSakIterator = lagretSakStream.iterator();
-      while (lagretSakIterator.hasNext()) {
-        var lagretSak = lagretSakIterator.next();
-        lagretSakService.delete(lagretSak.getId());
+    try (var lagretSakIdStream = lagretSakRepository.findIdsByBruker(bruker.getId())) {
+      var lagretSakIdIterator = lagretSakIdStream.iterator();
+      while (lagretSakIdIterator.hasNext()) {
+        lagretSakService.delete(lagretSakIdIterator.next());
       }
     }
 
     // Delete all LagretSoek
-    try (var lagretSoekStream = lagretSoekRepository.findByBruker(bruker.getId())) {
-      var lagretSoekIterator = lagretSoekStream.iterator();
-      while (lagretSoekIterator.hasNext()) {
-        var lagretSoek = lagretSoekIterator.next();
-        lagretSoekService.delete(lagretSoek.getId());
+    try (var lagretSoekIdStream = lagretSoekRepository.findIdsByBruker(bruker.getId())) {
+      var lagretSoekIdIterator = lagretSoekIdStream.iterator();
+      while (lagretSoekIdIterator.hasNext()) {
+        lagretSoekService.delete(lagretSoekIdIterator.next());
       }
     }
 

--- a/src/main/java/no/einnsyn/backend/entities/enhet/EnhetService.java
+++ b/src/main/java/no/einnsyn/backend/entities/enhet/EnhetService.java
@@ -376,47 +376,42 @@ public class EnhetService extends BaseService<Enhet, EnhetDTO> {
     }
 
     // Delete all Innsynskrav
-    try (var innsynskravStream = innsynskravRepository.findAllByEnhet(enhet)) {
-      var innsynskravIterator = innsynskravStream.iterator();
-      while (innsynskravIterator.hasNext()) {
-        var innsynskrav = innsynskravIterator.next();
-        innsynskravService.delete(innsynskrav.getId());
+    try (var innsynskravIdStream = innsynskravRepository.findIdsByEnhet(enhet)) {
+      var innsynskravIdIterator = innsynskravIdStream.iterator();
+      while (innsynskravIdIterator.hasNext()) {
+        innsynskravService.delete(innsynskravIdIterator.next());
       }
     }
 
     // Delete all Saksmappe by this enhet
-    try (var saksmappeSteram = saksmappeRepository.findAllByAdministrativEnhetObjekt(enhet)) {
-      var saksmappeIterator = saksmappeSteram.iterator();
-      while (saksmappeIterator.hasNext()) {
-        var saksmappe = saksmappeIterator.next();
-        saksmappeService.delete(saksmappe.getId());
+    try (var saksmappeIdSteram = saksmappeRepository.findIdsByAdministrativEnhetObjekt(enhet)) {
+      var saksmappeIdIterator = saksmappeIdSteram.iterator();
+      while (saksmappeIdIterator.hasNext()) {
+        saksmappeService.delete(saksmappeIdIterator.next());
       }
     }
 
     // Delete all Moetemappe by this enhet
-    try (var moetemappeStream = moetemappeRepository.findAllByUtvalgObjekt(enhet)) {
-      var moetemappeIterator = moetemappeStream.iterator();
-      while (moetemappeIterator.hasNext()) {
-        var moetemappe = moetemappeIterator.next();
-        moetemappeService.delete(moetemappe.getId());
+    try (var moetemappeIdStream = moetemappeRepository.findIdsByUtvalgObjekt(enhet)) {
+      var moetemappeIdIterator = moetemappeIdStream.iterator();
+      while (moetemappeIdIterator.hasNext()) {
+        moetemappeService.delete(moetemappeIdIterator.next());
       }
     }
 
     // Delete all Moetesak by this enhet
-    try (var moetesakStream = moetesakRepository.findAllByUtvalgObjekt(enhet)) {
-      var moetesakIterator = moetesakStream.iterator();
-      while (moetesakIterator.hasNext()) {
-        var moetesak = moetesakIterator.next();
-        moetesakService.delete(moetesak.getId());
+    try (var moetesakIdStream = moetesakRepository.findIdsByUtvalgObjekt(enhet)) {
+      var moetesakIdIterator = moetesakIdStream.iterator();
+      while (moetesakIdIterator.hasNext()) {
+        moetesakService.delete(moetesakIdIterator.next());
       }
     }
 
     // Delete all ApiKeys for this enhet
-    try (var apiKeyStream = apiKeyRepository.findAllByEnhet(enhet)) {
-      var apiKeyIterator = apiKeyStream.iterator();
-      while (apiKeyIterator.hasNext()) {
-        var apiKey = apiKeyIterator.next();
-        apiKeyService.delete(apiKey.getId());
+    try (var apiKeyStream = apiKeyRepository.findIdsByEnhet(enhet)) {
+      var apiKeyIdIterator = apiKeyStream.iterator();
+      while (apiKeyIdIterator.hasNext()) {
+        apiKeyService.delete(apiKeyIdIterator.next());
       }
     }
 

--- a/src/main/java/no/einnsyn/backend/entities/innsynskrav/InnsynskravRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/innsynskrav/InnsynskravRepository.java
@@ -21,7 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 public interface InnsynskravRepository
     extends BaseRepository<Innsynskrav>, IndexableRepository<Innsynskrav> {
 
-  Stream<Innsynskrav> findAllByEnhet(Enhet enhet);
+  @Query("SELECT o.id FROM Innsynskrav o WHERE enhet = :enhet")
+  Stream<String> findIdsByEnhet(Enhet enhet);
 
   Stream<Innsynskrav> findAllByJournalpost(Journalpost journalpost);
 

--- a/src/main/java/no/einnsyn/backend/entities/klasse/KlasseRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/klasse/KlasseRepository.java
@@ -11,11 +11,15 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface KlasseRepository extends ArkivBaseRepository<Klasse> {
 
-  Stream<Klasse> findAllByParentArkivdel(Arkivdel parentArkivdel);
+  @Query("SELECT o.id FROM Klasse o WHERE parentArkivdel = :parentArkivdel")
+  Stream<String> findIdsByParentArkivdel(Arkivdel parentArkivdel);
 
-  Stream<Klasse> findAllByParentKlasse(Klasse parentKlasse);
+  @Query("SELECT o.id FROM Klasse o WHERE parentKlasse = :parentKlasse")
+  Stream<String> findIdsByParentKlasse(Klasse parentKlasse);
 
-  Stream<Klasse> findAllByParentKlassifikasjonssystem(
+  @Query(
+      "SELECT o.id FROM Klasse o WHERE parentKlassifikasjonssystem = :parentKlassifikasjonssystem")
+  Stream<String> findIdsByParentKlassifikasjonssystem(
       Klassifikasjonssystem parentKlassifikasjonssystem);
 
   @Query(

--- a/src/main/java/no/einnsyn/backend/entities/klasse/KlasseService.java
+++ b/src/main/java/no/einnsyn/backend/entities/klasse/KlasseService.java
@@ -144,27 +144,24 @@ public class KlasseService extends ArkivBaseService<Klasse, KlasseDTO> {
 
   @Override
   protected void deleteEntity(Klasse object) throws EInnsynException {
-    try (var subKlasseStream = repository.findAllByParentKlasse(object)) {
-      var subKlasseIterator = subKlasseStream.iterator();
-      while (subKlasseIterator.hasNext()) {
-        var subKlasse = subKlasseIterator.next();
-        klasseService.delete(subKlasse.getId());
+    try (var subKlasseIdStream = repository.findIdsByParentKlasse(object)) {
+      var subKlasseIdIterator = subKlasseIdStream.iterator();
+      while (subKlasseIdIterator.hasNext()) {
+        klasseService.delete(subKlasseIdIterator.next());
       }
     }
 
-    try (var saksmappeStream = saksmappeRepository.findAllByParentKlasse(object)) {
-      var saksmappeIterator = saksmappeStream.iterator();
-      while (saksmappeIterator.hasNext()) {
-        var saksmappe = saksmappeIterator.next();
-        saksmappeService.delete(saksmappe.getId());
+    try (var saksmappeIdStream = saksmappeRepository.findAllByParentKlasse(object)) {
+      var saksmappeIdIterator = saksmappeIdStream.iterator();
+      while (saksmappeIdIterator.hasNext()) {
+        saksmappeService.delete(saksmappeIdIterator.next());
       }
     }
 
-    try (var moetemappeStream = moetemappeRepository.findAllByParentKlasse(object)) {
-      var moetemappeIterator = moetemappeStream.iterator();
-      while (moetemappeIterator.hasNext()) {
-        var moetemappe = moetemappeIterator.next();
-        moetemappeService.delete(moetemappe.getId());
+    try (var moetemappeIdStream = moetemappeRepository.findAllByParentKlasse(object)) {
+      var moetemappeIdIterator = moetemappeIdStream.iterator();
+      while (moetemappeIdIterator.hasNext()) {
+        moetemappeService.delete(moetemappeIdIterator.next());
       }
     }
 

--- a/src/main/java/no/einnsyn/backend/entities/klassifikasjonssystem/KlassifikasjonssystemRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/klassifikasjonssystem/KlassifikasjonssystemRepository.java
@@ -4,8 +4,10 @@ import java.util.stream.Stream;
 import no.einnsyn.backend.entities.arkivbase.ArkivBaseRepository;
 import no.einnsyn.backend.entities.arkivdel.models.Arkivdel;
 import no.einnsyn.backend.entities.klassifikasjonssystem.models.Klassifikasjonssystem;
+import org.springframework.data.jpa.repository.Query;
 
 public interface KlassifikasjonssystemRepository
     extends ArkivBaseRepository<Klassifikasjonssystem> {
-  Stream<Klassifikasjonssystem> findByArkivdel(Arkivdel arkivdel);
+  @Query("SELECT o.id FROM Klassifikasjonssystem o WHERE arkivdel = :arkivdel")
+  Stream<String> findIdsByArkivdel(Arkivdel arkivdel);
 }

--- a/src/main/java/no/einnsyn/backend/entities/klassifikasjonssystem/KlassifikasjonssystemService.java
+++ b/src/main/java/no/einnsyn/backend/entities/klassifikasjonssystem/KlassifikasjonssystemService.java
@@ -78,11 +78,10 @@ public class KlassifikasjonssystemService
 
   @Override
   protected void deleteEntity(Klassifikasjonssystem object) throws EInnsynException {
-    try (var klasseStream = klasseRepository.findAllByParentKlassifikasjonssystem(object)) {
-      var klasseIterator = klasseStream.iterator();
-      while (klasseIterator.hasNext()) {
-        var klasse = klasseIterator.next();
-        klasseService.delete(klasse.getId());
+    try (var klasseIdStream = klasseRepository.findIdsByParentKlassifikasjonssystem(object)) {
+      var klasseIdIterator = klasseIdStream.iterator();
+      while (klasseIdIterator.hasNext()) {
+        klasseService.delete(klasseIdIterator.next());
       }
     }
 

--- a/src/main/java/no/einnsyn/backend/entities/lagretsak/LagretSakRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/lagretsak/LagretSakRepository.java
@@ -43,23 +43,14 @@ public interface LagretSakRepository extends BaseRepository<LagretSak> {
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   void resetHits(String lagretSakId);
 
-  @Query(
-      """
-      SELECT o FROM LagretSak o WHERE bruker.id = :brukerId ORDER BY id DESC
-      """)
-  Stream<LagretSak> findByBruker(String brukerId);
+  @Query("SELECT o.id FROM LagretSak o WHERE bruker.id = :brukerId ORDER BY id DESC")
+  Stream<String> findIdsByBruker(String brukerId);
 
-  @Query(
-      """
-      SELECT o FROM LagretSak o WHERE saksmappe.id = :saksmappeId ORDER BY id DESC
-      """)
-  Stream<LagretSak> findBySaksmappe(String saksmappeId);
+  @Query("SELECT o.id FROM LagretSak o WHERE saksmappe.id = :saksmappeId ORDER BY id DESC")
+  Stream<String> findIdsBySaksmappe(String saksmappeId);
 
-  @Query(
-      """
-      SELECT o FROM LagretSak o WHERE moetemappe.id = :moetemappeId ORDER BY id DESC
-      """)
-  Stream<LagretSak> findByMoetemappe(String moetemappeId);
+  @Query("SELECT o.id FROM LagretSak o WHERE moetemappe.id = :moetemappeId ORDER BY id DESC")
+  Stream<String> findIdsByMoetemappe(String moetemappeId);
 
   @Query(
       """

--- a/src/main/java/no/einnsyn/backend/entities/lagretsoek/LagretSoekRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/lagretsoek/LagretSoekRepository.java
@@ -70,11 +70,8 @@ public interface LagretSoekRepository extends BaseRepository<LagretSoek> {
   @Transactional(propagation = Propagation.REQUIRES_NEW)
   void deleteHits(List<String> idList);
 
-  @Query(
-      """
-      SELECT o FROM LagretSoek o WHERE bruker.id = :brukerId ORDER BY id DESC
-      """)
-  Stream<LagretSoek> findByBruker(String brukerId);
+  @Query("SELECT o.id FROM LagretSoek o WHERE bruker.id = :brukerId ORDER BY id DESC")
+  Stream<String> findIdsByBruker(String brukerId);
 
   @Query(
       """

--- a/src/main/java/no/einnsyn/backend/entities/mappe/MappeRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/mappe/MappeRepository.java
@@ -6,13 +6,17 @@ import no.einnsyn.backend.entities.arkivbase.ArkivBaseRepository;
 import no.einnsyn.backend.entities.arkivdel.models.Arkivdel;
 import no.einnsyn.backend.entities.klasse.models.Klasse;
 import no.einnsyn.backend.entities.mappe.models.Mappe;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.NoRepositoryBean;
 
 @NoRepositoryBean
 public interface MappeRepository<T extends Mappe> extends ArkivBaseRepository<T> {
-  Stream<T> findAllByParentArkiv(Arkiv parentArkiv);
+  @Query("SELECT o.id FROM #{#entityName} o WHERE parentArkiv = :parentArkiv")
+  Stream<String> findIdsByParentArkiv(Arkiv parentArkiv);
 
-  Stream<T> findAllByParentArkivdel(Arkivdel parentArkivdel);
+  @Query("SELECT o.id FROM #{#entityName} o WHERE parentArkivdel = :parentArkivdel")
+  Stream<String> findIdsByParentArkivdel(Arkivdel parentArkivdel);
 
-  Stream<T> findAllByParentKlasse(Klasse parentKlasse);
+  @Query("SELECT o.id FROM #{#entityName} o WHERE parentKlasse = :parentKlasse")
+  Stream<String> findAllByParentKlasse(Klasse parentKlasse);
 }

--- a/src/main/java/no/einnsyn/backend/entities/moetemappe/MoetemappeRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetemappe/MoetemappeRepository.java
@@ -71,7 +71,8 @@ public interface MoetemappeRepository
       """)
   Slice<Moetemappe> paginateDesc(Enhet utvalgObjekt, String pivot, Pageable pageable);
 
-  Stream<Moetemappe> findAllByUtvalgObjekt(Enhet administrativEnhetObjekt);
+  @Query("SELECT o.id FROM Moetemappe o WHERE utvalgObjekt = :utvalgObjekt")
+  Stream<String> findIdsByUtvalgObjekt(Enhet utvalgObjekt);
 
   @Query(
       value =

--- a/src/main/java/no/einnsyn/backend/entities/moetemappe/MoetemappeService.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetemappe/MoetemappeService.java
@@ -265,10 +265,10 @@ public class MoetemappeService extends MappeService<Moetemappe, MoetemappeDTO> {
     }
 
     // Delete all LagretSak
-    try (var lagretSakStream = lagretSakRepository.findByMoetemappe(moetemappe.getId())) {
-      var lagretSakIterator = lagretSakStream.iterator();
-      while (lagretSakIterator.hasNext()) {
-        lagretSakService.delete(lagretSakIterator.next().getId());
+    try (var lagretSakIdStream = lagretSakRepository.findIdsByMoetemappe(moetemappe.getId())) {
+      var lagretSakIdIterator = lagretSakIdStream.iterator();
+      while (lagretSakIdIterator.hasNext()) {
+        lagretSakService.delete(lagretSakIdIterator.next());
       }
     }
 

--- a/src/main/java/no/einnsyn/backend/entities/moetesak/MoetesakRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetesak/MoetesakRepository.java
@@ -54,7 +54,8 @@ public interface MoetesakRepository
       """)
   Slice<Moetesak> paginateDesc(Enhet utvalgObjekt, String pivot, Pageable pageable);
 
-  Stream<Moetesak> findAllByUtvalgObjekt(Enhet utvalgObjekt);
+  @Query("SELECT o.id FROM Moetesak o WHERE utvalgObjekt = :utvalgObjekt")
+  Stream<String> findIdsByUtvalgObjekt(Enhet utvalgObjekt);
 
   @Query(
       "SELECT COUNT(m) FROM Moetesak m JOIN m.dokumentbeskrivelse d WHERE d = :dokumentbeskrivelse")

--- a/src/main/java/no/einnsyn/backend/entities/saksmappe/SaksmappeRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/saksmappe/SaksmappeRepository.java
@@ -68,5 +68,6 @@ public interface SaksmappeRepository
       """)
   Slice<Saksmappe> paginateDesc(Enhet administrativEnhetObjekt, String pivot, Pageable pageable);
 
-  Stream<Saksmappe> findAllByAdministrativEnhetObjekt(Enhet administrativEnhetObjekt);
+  @Query("SELECT o.id FROM Saksmappe o WHERE administrativEnhetObjekt = :administrativEnhetObjekt")
+  Stream<String> findIdsByAdministrativEnhetObjekt(Enhet administrativEnhetObjekt);
 }

--- a/src/main/java/no/einnsyn/backend/entities/saksmappe/SaksmappeService.java
+++ b/src/main/java/no/einnsyn/backend/entities/saksmappe/SaksmappeService.java
@@ -231,11 +231,10 @@ public class SaksmappeService extends MappeService<Saksmappe, SaksmappeDTO> {
     }
 
     // Delete all LagretSak
-    try (var lagretSakStream = lagretSakRepository.findBySaksmappe(saksmappe.getId())) {
-      var lagretSakIterator = lagretSakStream.iterator();
-      while (lagretSakIterator.hasNext()) {
-        var lagretSak = lagretSakIterator.next();
-        lagretSakRepository.delete(lagretSak);
+    try (var lagretSakIdStream = lagretSakRepository.findIdsBySaksmappe(saksmappe.getId())) {
+      var lagretSakIdIterator = lagretSakIdStream.iterator();
+      while (lagretSakIdIterator.hasNext()) {
+        lagretSakService.delete(lagretSakIdIterator.next());
       }
     }
 

--- a/src/main/java/no/einnsyn/backend/tasks/handlers/index/ElasticsearchIndexQueue.java
+++ b/src/main/java/no/einnsyn/backend/tasks/handlers/index/ElasticsearchIndexQueue.java
@@ -84,5 +84,6 @@ public class ElasticsearchIndexQueue {
             "Failed to index {} with id: {}: {}", clazz.getSimpleName(), id, e.getMessage(), e);
       }
     }
+    queueMap.clear();
   }
 }

--- a/src/main/java/no/einnsyn/backend/tasks/handlers/reindex/ElasticsearchReindexScheduler.java
+++ b/src/main/java/no/einnsyn/backend/tasks/handlers/reindex/ElasticsearchReindexScheduler.java
@@ -158,9 +158,9 @@ public class ElasticsearchReindexScheduler {
       var foundJournalpost = new AtomicInteger(0);
       var journalpostIdIterator = journalpostIdStream.iterator();
       while (journalpostIdIterator.hasNext()) {
-        var journalpost = journalpostIdIterator.next();
+        var journalpostId = journalpostIdIterator.next();
         foundJournalpost.addAndGet(1);
-        parallelRunner.run(() -> journalpostService.index(journalpost));
+        parallelRunner.run(() -> journalpostService.index(journalpostId));
         lastExtended = proxy.maybeExtendLock(lastExtended);
         maybeClearEntityManager(foundJournalpost.get());
       }

--- a/src/main/java/no/einnsyn/backend/tasks/handlers/subscription/SubscriptionMatcher.java
+++ b/src/main/java/no/einnsyn/backend/tasks/handlers/subscription/SubscriptionMatcher.java
@@ -111,7 +111,12 @@ public class SubscriptionMatcher {
     // Create new LagretSoekTreff for each hit
     while (iterator.hasNext()) {
       var hit = iterator.next();
-      lagretSoekService.addHit(document, hit.id());
+      try {
+        lagretSoekService.addHit(document.getType().getFirst(), document.getId(), hit.id());
+      } catch (Exception e) {
+        log.error(
+            "Failed to add hit for document with id: {}: {}", document.getId(), e.getMessage(), e);
+      }
     }
   }
 

--- a/src/main/java/no/einnsyn/backend/tasks/handlers/subscription/SubscriptionScheduler.java
+++ b/src/main/java/no/einnsyn/backend/tasks/handlers/subscription/SubscriptionScheduler.java
@@ -53,10 +53,10 @@ public class SubscriptionScheduler {
   public void notifyLagretSak() {
     var lastExtended = System.currentTimeMillis();
     try (var matchingSak = lagretSakRepository.findLagretSakWithHits()) {
-      var matchingSakIterator = matchingSak.iterator();
+      var matchingSakIdIterator = matchingSak.iterator();
       log.debug("Notify matching lagretSak");
-      while (matchingSakIterator.hasNext()) {
-        var sakId = matchingSakIterator.next();
+      while (matchingSakIdIterator.hasNext()) {
+        var sakId = matchingSakIdIterator.next();
         log.info("Notifying lagretSak {}", sakId);
         lagretSakService.notifyLagretSak(sakId);
         lastExtended = maybeExtendLock(lastExtended);
@@ -72,11 +72,11 @@ public class SubscriptionScheduler {
   @Transactional(readOnly = true)
   public void notifyLagretSoek() {
     var lastExtended = System.currentTimeMillis();
-    try (var matchingSoek = lagretSoekRepository.findBrukerWithLagretSoekHits()) {
-      var matchingSoekIterator = matchingSoek.iterator();
+    try (var matchingSoekBrukerId = lagretSoekRepository.findBrukerWithLagretSoekHits()) {
+      var matchingSoekBrukerIdIterator = matchingSoekBrukerId.iterator();
       log.info("Notify matching lagretSoek");
-      while (matchingSoekIterator.hasNext()) {
-        var brukerId = matchingSoekIterator.next();
+      while (matchingSoekBrukerIdIterator.hasNext()) {
+        var brukerId = matchingSoekBrukerIdIterator.next();
         log.debug("Notifying lagretSoek for bruker {}", brukerId);
         lagretSoekService.notifyLagretSoek(brukerId);
         lastExtended = maybeExtendLock(lastExtended);


### PR DESCRIPTION
For most streamed db-queries, we only need the ID, not the entire object.