### PR TITLE
EIN-X: Use `createOrReturnExisting` when adding dokumentbeskrivelse

### DIFF
--- a/src/main/java/no/einnsyn/backend/entities/journalpost/JournalpostService.java
+++ b/src/main/java/no/einnsyn/backend/entities/journalpost/JournalpostService.java
@@ -29,6 +29,8 @@ import no.einnsyn.backend.entities.skjerming.models.SkjermingES;
 import no.einnsyn.backend.utils.TimeConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -607,30 +609,16 @@ public class JournalpostService extends RegistreringService<Journalpost, Journal
    * @throws EInnsynException
    */
   @Transactional(rollbackFor = Exception.class)
-  @Retryable
+  @Retryable(
+      retryFor = {ObjectOptimisticLockingFailureException.class},
+      backoff = @Backoff(delay = 100, random = true))
   public DokumentbeskrivelseDTO addDokumentbeskrivelse(
       String journalpostId, ExpandableField<DokumentbeskrivelseDTO> dokumentbeskrivelseField)
       throws EInnsynException {
 
-    var dokumentbeskrivelseDTO =
-        dokumentbeskrivelseField.getId() == null
-            ? dokumentbeskrivelseService.add(dokumentbeskrivelseField.getExpandedObject())
-            : dokumentbeskrivelseService.get(dokumentbeskrivelseField.getId());
-
-    var dokumentbeskrivelse = dokumentbeskrivelseService.findById(dokumentbeskrivelseDTO.getId());
+    var dokumentbeskrivelse =
+        dokumentbeskrivelseService.createOrReturnExisting(dokumentbeskrivelseField);
     var journalpost = journalpostService.findById(journalpostId);
-    journalpost.addDokumentbeskrivelse(dokumentbeskrivelse);
-    journalpostService.scheduleIndex(journalpost, -1);
-
-    return dokumentbeskrivelseDTO;
-  }
-
-  @Transactional(rollbackFor = Exception.class)
-  @Retryable
-  public DokumentbeskrivelseDTO addDokumentbeskrivelse(
-      String journalpostId, String dokumentbeskrivelseId) throws EInnsynException {
-    var journalpost = journalpostService.findById(journalpostId);
-    var dokumentbeskrivelse = dokumentbeskrivelseService.findById(dokumentbeskrivelseId);
     journalpost.addDokumentbeskrivelse(dokumentbeskrivelse);
     journalpostService.scheduleIndex(journalpost, -1);
 


### PR DESCRIPTION
Support adding existing Dokumentbeskrivelse by looking up the SystemID field