### PR TITLE
EIN-X: Replace `orgnummer` in metrics tags

### DIFF
--- a/src/main/java/no/einnsyn/backend/configuration/MetricConfiguration.java
+++ b/src/main/java/no/einnsyn/backend/configuration/MetricConfiguration.java
@@ -24,6 +24,9 @@ public class MetricConfiguration {
           // Replace email-addresses
           uri = uri.replaceAll("[^/]+@[^/]+", "{email}");
 
+          // Replace organization numbers
+          uri = uri.replaceAll("[0-9]{9}", "{orgnr}");
+
           // Replace UUIDs (Noark system-id)
           uri =
               uri.replaceAll(

--- a/src/main/java/no/einnsyn/backend/configuration/MetricConfiguration.java
+++ b/src/main/java/no/einnsyn/backend/configuration/MetricConfiguration.java
@@ -25,7 +25,7 @@ public class MetricConfiguration {
           uri = uri.replaceAll("[^/]+@[^/]+", "{email}");
 
           // Replace organization numbers
-          uri = uri.replaceAll("[0-9]{9}", "{orgnr}");
+          uri = uri.replaceAll("\\b[0-9]{9}\\b", "{orgnr}");
 
           // Replace UUIDs (Noark system-id)
           uri =


### PR DESCRIPTION
`orgnummer` can be used as IDs in path names, and should be stripped in metrics.