### PR TITLE
EIN-4962: Bump metaspace limit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,8 @@
             <env>
               <BPE_DEFAULT_LANG>en_US.UTF-8</BPE_DEFAULT_LANG>
               <BP_HEALTH_CHECKER_ENABLED>true</BP_HEALTH_CHECKER_ENABLED>
+              <!-- Bump Paketo's class-count estimate to avoid undersized metaspace after dependency/image reduction. -->
+              <BPE_DEFAULT_BPL_JVM_CLASS_ADJUSTMENT>120%</BPE_DEFAULT_BPL_JVM_CLASS_ADJUSTMENT>
             </env>
             <buildpacks>
               <buildpack>paketobuildpacks/java:latest</buildpack>


### PR DESCRIPTION
Paketo underestimated loaded classes after removing ip-client dependency, resulting in an OOM: Metaspace. Bump class-count for a safer metaspace limit.