### PR TITLE
chore: EIN-4977: Remove usage of maven-settings-action

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -23,20 +23,9 @@ jobs:
           java-version: "25"
           distribution: "temurin"
           cache: maven
-
-      - uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # pin@v4.0.0
-        with:
-          servers: |
-            [{
-                "id": "github-oidc-sdk",
-                "username": "${{ secrets.MAVEN_USER }}",
-                "password": "${{ secrets.MAVEN_PASSWORD }}"
-            },
-            {
-                "id": "github",
-                "username": "${{ secrets.MAVEN_USER }}",
-                "password": "${{ secrets.MAVEN_PASSWORD }}"
-            }]
+          server-id: 'github'
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
 
       - name: Pull testcontainer images
         run: >-
@@ -46,6 +35,9 @@ jobs:
 
       - name: Run tests with coverage
         run: mvn clean test
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USER }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
 
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@v2


### PR DESCRIPTION
`actions/setup-java` Uses environment variables in the maven settings file. Thus we only need to set those variables on the step where maven does any work.