### PR TITLE
fix: do not trigger Mappe-subscription alerts on scheduled reindex (EIN-4981)

### DIFF
--- a/src/main/java/no/einnsyn/backend/entities/base/BaseRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/base/BaseRepository.java
@@ -5,8 +5,11 @@ import java.util.List;
 import no.einnsyn.backend.entities.base.models.Base;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.transaction.annotation.Transactional;
 
 @NoRepositoryBean
 public interface BaseRepository<T extends Base> extends CrudRepository<T, String> {
@@ -22,6 +25,11 @@ public interface BaseRepository<T extends Base> extends CrudRepository<T, String
   void deleteById(@NotNull String id);
 
   T saveAndFlush(T object);
+
+  @Transactional
+  @Modifying
+  @Query("UPDATE #{#entityName} e SET e.updated = CURRENT_TIMESTAMP WHERE e.id = :id")
+  void touchUpdated(String id);
 
   Slice<T> findAllByOrderByIdDesc(Pageable pageable);
 

--- a/src/main/java/no/einnsyn/backend/entities/base/BaseRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/base/BaseRepository.java
@@ -1,6 +1,7 @@
 package no.einnsyn.backend.entities.base;
 
 import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
 import java.util.List;
 import no.einnsyn.backend.entities.base.models.Base;
 import org.springframework.data.domain.Pageable;
@@ -28,8 +29,8 @@ public interface BaseRepository<T extends Base> extends CrudRepository<T, String
 
   @Transactional
   @Modifying
-  @Query("UPDATE #{#entityName} e SET e.updated = CURRENT_TIMESTAMP WHERE e.id = :id")
-  void touchUpdated(String id);
+  @Query("UPDATE #{#entityName} e SET e.updated = :updated WHERE e.id = :id")
+  void touchUpdated(String id, Instant updated);
 
   Slice<T> findAllByOrderByIdDesc(Pageable pageable);
 

--- a/src/main/java/no/einnsyn/backend/entities/base/BaseService.java
+++ b/src/main/java/no/einnsyn/backend/entities/base/BaseService.java
@@ -882,6 +882,9 @@ public abstract class BaseService<O extends Base, D extends BaseDTO> {
       // This keeps stale detection race-safe while also preventing endless reindex loops when
       // accessibleAfter is greater than the last updated timestamp.
       var objectUpdated = object.getUpdated();
+      var lastIndexed = indexable.getLastIndexed();
+      var updatedSinceLastIndex =
+          objectUpdated != null && (lastIndexed == null || objectUpdated.isAfter(lastIndexed));
       var lastIndexedTimestamp =
           objectUpdated != null && objectUpdated.isAfter(timestamp) ? objectUpdated : timestamp;
       var esDocument = proxy.toLegacyES(object);
@@ -907,7 +910,6 @@ public abstract class BaseService<O extends Base, D extends BaseDTO> {
       }
 
       var isInsert = false;
-      var lastIndexed = indexable.getLastIndexed();
       var accessibleAfter = esDocument.getAccessibleAfter();
       log.debug(
           "index {} : {} routing: {} lastIndexed: {}", objectClassName, id, esParent, lastIndexed);
@@ -941,7 +943,8 @@ public abstract class BaseService<O extends Base, D extends BaseDTO> {
         if (repository instanceof IndexableRepository<?> indexableRepository) {
           indexableRepository.updateLastIndexed(id, lastIndexedTimestamp);
         }
-        eventPublisher.publishEvent(new IndexEvent(this, esDocument, isInsert));
+        eventPublisher.publishEvent(
+            new IndexEvent(this, esDocument, isInsert, updatedSinceLastIndex));
         log.info(
             "indexed {} : {} routing: {} lastIndexed: {}",
             objectClassName,

--- a/src/main/java/no/einnsyn/backend/entities/dokumentbeskrivelse/DokumentbeskrivelseService.java
+++ b/src/main/java/no/einnsyn/backend/entities/dokumentbeskrivelse/DokumentbeskrivelseService.java
@@ -80,10 +80,10 @@ public class DokumentbeskrivelseService
    */
   @Override
   public boolean scheduleIndex(String dokumentbeskrivelseId, int recurseDirection) {
-    var isScheduled = super.scheduleIndex(dokumentbeskrivelseId, recurseDirection);
+    var wasAlreadyScheduled = super.scheduleIndex(dokumentbeskrivelseId, recurseDirection);
 
     // Reindex parents
-    if (recurseDirection <= 0 && !isScheduled) {
+    if (recurseDirection <= 0 && !wasAlreadyScheduled) {
       try (var journalpostStream =
           journalpostRepository.streamIdByDokumentbeskrivelseId(dokumentbeskrivelseId)) {
         journalpostStream.forEach(id -> journalpostService.scheduleIndex(id, -1));
@@ -98,7 +98,7 @@ public class DokumentbeskrivelseService
       }
     }
 
-    return true;
+    return wasAlreadyScheduled;
   }
 
   /**

--- a/src/main/java/no/einnsyn/backend/entities/dokumentobjekt/DokumentobjektService.java
+++ b/src/main/java/no/einnsyn/backend/entities/dokumentobjekt/DokumentobjektService.java
@@ -85,10 +85,10 @@ public class DokumentobjektService extends ArkivBaseService<Dokumentobjekt, Doku
    */
   @Override
   public boolean scheduleIndex(String dokumentobjektId, int recurseDirection) {
-    var isScheduled = super.scheduleIndex(dokumentobjektId, recurseDirection);
+    var wasAlreadyScheduled = super.scheduleIndex(dokumentobjektId, recurseDirection);
 
     // Reindex parents
-    if (recurseDirection <= 0 && !isScheduled) {
+    if (recurseDirection <= 0 && !wasAlreadyScheduled) {
       var dokumentbeskrivelseId =
           dokumentbeskrivelseRepository.findIdByDokumentobjektId(dokumentobjektId);
       if (dokumentbeskrivelseId != null) {
@@ -96,7 +96,7 @@ public class DokumentobjektService extends ArkivBaseService<Dokumentobjekt, Doku
       }
     }
 
-    return true;
+    return wasAlreadyScheduled;
   }
 
   /**

--- a/src/main/java/no/einnsyn/backend/entities/innsynskravbestilling/InnsynskravBestillingService.java
+++ b/src/main/java/no/einnsyn/backend/entities/innsynskravbestilling/InnsynskravBestillingService.java
@@ -111,17 +111,17 @@ public class InnsynskravBestillingService
    */
   @Override
   public boolean scheduleIndex(String innsynskravBestillingId, int recurseDirection) {
-    var isScheduled = super.scheduleIndex(innsynskravBestillingId, recurseDirection);
+    var wasAlreadyScheduled = super.scheduleIndex(innsynskravBestillingId, recurseDirection);
 
     // Reindex innsynskrav
-    if (recurseDirection >= 0 && !isScheduled) {
+    if (recurseDirection >= 0 && !wasAlreadyScheduled) {
       try (var innsynskravStream =
           innsynskravRepository.streamIdByInnsynskravBestillingId(innsynskravBestillingId)) {
         innsynskravStream.forEach(id -> innsynskravService.scheduleIndex(id, 1));
       }
     }
 
-    return true;
+    return wasAlreadyScheduled;
   }
 
   /**

--- a/src/main/java/no/einnsyn/backend/entities/journalpost/JournalpostService.java
+++ b/src/main/java/no/einnsyn/backend/entities/journalpost/JournalpostService.java
@@ -41,6 +41,7 @@ import org.springframework.resilience.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
 
 @Service
 @SuppressWarnings("java:S1192") // Allow multiple string literals
@@ -88,17 +89,21 @@ public class JournalpostService extends RegistreringService<Journalpost, Journal
    */
   @Override
   public boolean scheduleIndex(String journalpostId, int recurseDirection) {
-    var isScheduled = super.scheduleIndex(journalpostId, recurseDirection);
+    var wasAlreadyScheduled = super.scheduleIndex(journalpostId, recurseDirection);
 
     // Index saksmappe
-    if (recurseDirection <= 0 && !isScheduled) {
+    // Check that we're in a request scope.
+    if (recurseDirection <= 0 && RequestContextHolder.getRequestAttributes() != null) {
       var saksmappeId = saksmappeRepository.findIdByJournalpostId(journalpostId);
       if (saksmappeId != null) {
-        saksmappeService.scheduleIndex(saksmappeId, -1);
+        var parentWasAlreadyScheduled = saksmappeService.scheduleIndex(saksmappeId, -1);
+        if (!parentWasAlreadyScheduled) {
+          saksmappeRepository.touchUpdated(saksmappeId);
+        }
       }
     }
 
-    return true;
+    return wasAlreadyScheduled;
   }
 
   /**

--- a/src/main/java/no/einnsyn/backend/entities/journalpost/JournalpostService.java
+++ b/src/main/java/no/einnsyn/backend/entities/journalpost/JournalpostService.java
@@ -1,6 +1,7 @@
 package no.einnsyn.backend.entities.journalpost;
 
 import jakarta.validation.constraints.NotNull;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
@@ -98,7 +99,7 @@ public class JournalpostService extends RegistreringService<Journalpost, Journal
       if (saksmappeId != null) {
         var parentWasAlreadyScheduled = saksmappeService.scheduleIndex(saksmappeId, -1);
         if (!parentWasAlreadyScheduled) {
-          saksmappeRepository.touchUpdated(saksmappeId);
+          saksmappeRepository.touchUpdated(saksmappeId, Instant.now());
         }
       }
     }

--- a/src/main/java/no/einnsyn/backend/entities/korrespondansepart/KorrespondansepartService.java
+++ b/src/main/java/no/einnsyn/backend/entities/korrespondansepart/KorrespondansepartService.java
@@ -65,31 +65,31 @@ public class KorrespondansepartService
    */
   @Override
   public boolean scheduleIndex(String korrespondansepartId, int recurseDirection) {
-    var isScheduled = super.scheduleIndex(korrespondansepartId, recurseDirection);
+    var wasAlreadyScheduled = super.scheduleIndex(korrespondansepartId, recurseDirection);
 
     // Reindex parents
-    if (recurseDirection <= 0 && !isScheduled) {
+    if (recurseDirection <= 0 && !wasAlreadyScheduled) {
       var journalpostId = journalpostRepository.findIdByKorrespondansepartId(korrespondansepartId);
       if (journalpostId != null) {
         journalpostService.scheduleIndex(journalpostId, -1);
-        return true;
+        return wasAlreadyScheduled;
       }
 
       var moetesakId = moetesakRepository.findIdByKorrespondansepartId(korrespondansepartId);
       if (moetesakId != null) {
         moetesakService.scheduleIndex(moetesakId, -1);
-        return true;
+        return wasAlreadyScheduled;
       }
 
       var moetedokumentId =
           moetedokumentRepository.findByKorrespondansepartId(korrespondansepartId);
       if (moetedokumentId != null) {
         moetedokumentService.scheduleIndex(moetedokumentId, -1);
-        return true;
+        return wasAlreadyScheduled;
       }
     }
 
-    return true;
+    return wasAlreadyScheduled;
   }
 
   /**

--- a/src/main/java/no/einnsyn/backend/entities/lagretsak/LagretSakRepository.java
+++ b/src/main/java/no/einnsyn/backend/entities/lagretsak/LagretSakRepository.java
@@ -1,5 +1,6 @@
 package no.einnsyn.backend.entities.lagretsak;
 
+import java.time.Instant;
 import java.util.stream.Stream;
 import no.einnsyn.backend.entities.base.BaseRepository;
 import no.einnsyn.backend.entities.bruker.models.Bruker;
@@ -23,9 +24,10 @@ public interface LagretSakRepository extends BaseRepository<LagretSak> {
       SET hitCount = hitCount + 1
       WHERE saksmappe.id = :mappeId
       AND subscribe = true
+      AND created <= :updated
       """)
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  void addHitBySaksmappe(String mappeId);
+  void addHitBySaksmappe(String mappeId, Instant updated);
 
   @Modifying
   @Query(
@@ -34,9 +36,10 @@ public interface LagretSakRepository extends BaseRepository<LagretSak> {
       hitCount = hitCount + 1
       WHERE moetemappe.id = :mappeId
       AND subscribe = true
+      AND created <= :updated
       """)
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  void addHitByMoetemappe(String mappeId);
+  void addHitByMoetemappe(String mappeId, Instant updated);
 
   @Modifying
   @Query("UPDATE LagretSak SET hitCount = 0 WHERE id = :lagretSakId")

--- a/src/main/java/no/einnsyn/backend/entities/moetedokument/MoetedokumentService.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetedokument/MoetedokumentService.java
@@ -1,5 +1,6 @@
 package no.einnsyn.backend.entities.moetedokument;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import lombok.Getter;
@@ -76,7 +77,7 @@ public class MoetedokumentService extends RegistreringService<Moetedokument, Moe
       if (moetemappeId != null) {
         var parentWasAlreadyScheduled = moetemappeService.scheduleIndex(moetemappeId, -1);
         if (!parentWasAlreadyScheduled) {
-          moetemappeRepository.touchUpdated(moetemappeId);
+          moetemappeRepository.touchUpdated(moetemappeId, Instant.now());
         }
       }
     }

--- a/src/main/java/no/einnsyn/backend/entities/moetedokument/MoetedokumentService.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetedokument/MoetedokumentService.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.resilience.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
 
 @Service
 @Slf4j
@@ -66,17 +67,21 @@ public class MoetedokumentService extends RegistreringService<Moetedokument, Moe
    */
   @Override
   public boolean scheduleIndex(String moetedokumentId, int recurseDirection) {
-    var isScheduled = super.scheduleIndex(moetedokumentId, recurseDirection);
+    var wasAlreadyScheduled = super.scheduleIndex(moetedokumentId, recurseDirection);
 
     // Reindex parent
-    if (recurseDirection <= 0 && !isScheduled) {
+    // Check that we're in a request scope.
+    if (recurseDirection <= 0 && RequestContextHolder.getRequestAttributes() != null) {
       var moetemappeId = moetemappeRepository.findIdByMoetedokumentId(moetedokumentId);
       if (moetemappeId != null) {
-        moetemappeService.scheduleIndex(moetemappeId, -1);
+        var parentWasAlreadyScheduled = moetemappeService.scheduleIndex(moetemappeId, -1);
+        if (!parentWasAlreadyScheduled) {
+          moetemappeRepository.touchUpdated(moetemappeId);
+        }
       }
     }
 
-    return true;
+    return wasAlreadyScheduled;
   }
 
   @Override

--- a/src/main/java/no/einnsyn/backend/entities/moetemappe/MoetemappeService.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetemappe/MoetemappeService.java
@@ -72,15 +72,15 @@ public class MoetemappeService extends MappeService<Moetemappe, MoetemappeDTO> {
    */
   @Override
   public boolean scheduleIndex(String moetemappeId, int recurseDirection) {
-    var isScheduled = super.scheduleIndex(moetemappeId, recurseDirection);
+    var wasAlreadyScheduled = super.scheduleIndex(moetemappeId, recurseDirection);
 
-    if (recurseDirection >= 0 && !isScheduled) {
+    if (recurseDirection >= 0 && !wasAlreadyScheduled) {
       try (var moetesakStream = moetesakRepository.streamIdByMoetemappeId(moetemappeId)) {
         moetesakStream.forEach(id -> moetesakService.scheduleIndex(id, 1));
       }
     }
 
-    return true;
+    return wasAlreadyScheduled;
   }
 
   @Override

--- a/src/main/java/no/einnsyn/backend/entities/moetesak/MoetesakService.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetesak/MoetesakService.java
@@ -35,6 +35,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.resilience.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
 
 @Service
 @Slf4j
@@ -82,17 +83,21 @@ public class MoetesakService extends RegistreringService<Moetesak, MoetesakDTO> 
    */
   @Override
   public boolean scheduleIndex(String moetesakId, int recurseDirection) {
-    var isScheduled = super.scheduleIndex(moetesakId, recurseDirection);
+    var wasAlreadyScheduled = super.scheduleIndex(moetesakId, recurseDirection);
 
     // Index moetemappe
-    if (recurseDirection <= 0 && !isScheduled) {
+    // Check that we're in a request scope.
+    if (recurseDirection <= 0 && RequestContextHolder.getRequestAttributes() != null) {
       var moetemappeId = moetemappeRepository.findIdByMoetesakId(moetesakId);
       if (moetemappeId != null) {
-        moetemappeService.scheduleIndex(moetemappeId, -1);
+        var parentWasAlreadyScheduled = moetemappeService.scheduleIndex(moetemappeId, -1);
+        if (!parentWasAlreadyScheduled) {
+          moetemappeRepository.touchUpdated(moetemappeId);
+        }
       }
     }
 
-    return true;
+    return wasAlreadyScheduled;
   }
 
   @Override

--- a/src/main/java/no/einnsyn/backend/entities/moetesak/MoetesakService.java
+++ b/src/main/java/no/einnsyn/backend/entities/moetesak/MoetesakService.java
@@ -1,5 +1,6 @@
 package no.einnsyn.backend.entities.moetesak;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import lombok.Getter;
@@ -92,7 +93,7 @@ public class MoetesakService extends RegistreringService<Moetesak, MoetesakDTO> 
       if (moetemappeId != null) {
         var parentWasAlreadyScheduled = moetemappeService.scheduleIndex(moetemappeId, -1);
         if (!parentWasAlreadyScheduled) {
-          moetemappeRepository.touchUpdated(moetemappeId);
+          moetemappeRepository.touchUpdated(moetemappeId, Instant.now());
         }
       }
     }

--- a/src/main/java/no/einnsyn/backend/entities/saksmappe/SaksmappeService.java
+++ b/src/main/java/no/einnsyn/backend/entities/saksmappe/SaksmappeService.java
@@ -71,15 +71,15 @@ public class SaksmappeService extends MappeService<Saksmappe, SaksmappeDTO> {
    */
   @Override
   public boolean scheduleIndex(String saksmappeId, int recurseDirection) {
-    var isScheduled = super.scheduleIndex(saksmappeId, recurseDirection);
+    var wasAlreadyScheduled = super.scheduleIndex(saksmappeId, recurseDirection);
 
-    if (recurseDirection >= 0 && !isScheduled) {
+    if (recurseDirection >= 0 && !wasAlreadyScheduled) {
       try (var journalpostStream = journalpostRepository.streamIdBySaksmappeId(saksmappeId)) {
         journalpostStream.forEach(id -> journalpostService.scheduleIndex(id, 1));
       }
     }
 
-    return true;
+    return wasAlreadyScheduled;
   }
 
   /**

--- a/src/main/java/no/einnsyn/backend/entities/skjerming/SkjermingService.java
+++ b/src/main/java/no/einnsyn/backend/entities/skjerming/SkjermingService.java
@@ -104,16 +104,16 @@ public class SkjermingService extends ArkivBaseService<Skjerming, SkjermingDTO> 
    */
   @Override
   public boolean scheduleIndex(String skjermingId, int recurseDirection) {
-    var isScheduled = super.scheduleIndex(skjermingId, recurseDirection);
+    var wasAlreadyScheduled = super.scheduleIndex(skjermingId, recurseDirection);
 
     // Reindex parents
-    if (recurseDirection <= 0 && !isScheduled) {
+    if (recurseDirection <= 0 && !wasAlreadyScheduled) {
       try (var journalpostStream = journalpostRepository.streamIdBySkjermingId(skjermingId)) {
         journalpostStream.forEach(id -> journalpostService.scheduleIndex(id, -1));
       }
     }
 
-    return true;
+    return wasAlreadyScheduled;
   }
 
   /**

--- a/src/main/java/no/einnsyn/backend/entities/utredning/UtredningService.java
+++ b/src/main/java/no/einnsyn/backend/entities/utredning/UtredningService.java
@@ -54,17 +54,17 @@ public class UtredningService extends ArkivBaseService<Utredning, UtredningDTO> 
    */
   @Override
   public boolean scheduleIndex(String utredningId, int recurseDirection) {
-    var isScheduled = super.scheduleIndex(utredningId, recurseDirection);
+    var wasAlreadyScheduled = super.scheduleIndex(utredningId, recurseDirection);
 
     // Index moetesak
-    if (recurseDirection <= 0 && !isScheduled) {
+    if (recurseDirection <= 0 && !wasAlreadyScheduled) {
       var moetesakId = moetesakRepository.findIdByUtredningId(utredningId);
       if (moetesakId != null) {
         moetesakService.scheduleIndex(moetesakId, -1);
       }
     }
 
-    return true;
+    return wasAlreadyScheduled;
   }
 
   @Override

--- a/src/main/java/no/einnsyn/backend/entities/vedtak/VedtakService.java
+++ b/src/main/java/no/einnsyn/backend/entities/vedtak/VedtakService.java
@@ -56,17 +56,17 @@ public class VedtakService extends ArkivBaseService<Vedtak, VedtakDTO> {
    */
   @Override
   public boolean scheduleIndex(String vedtakId, int recurseDirection) {
-    var isScheduled = super.scheduleIndex(vedtakId, recurseDirection);
+    var wasAlreadyScheduled = super.scheduleIndex(vedtakId, recurseDirection);
 
     // Index moetesak
-    if (recurseDirection <= 0 && !isScheduled) {
+    if (recurseDirection <= 0 && !wasAlreadyScheduled) {
       var moetesakId = moetesakRepository.findIdByVedtakId(vedtakId);
       if (moetesakId != null) {
         moetesakService.scheduleIndex(moetesakId, -1);
       }
     }
 
-    return true;
+    return wasAlreadyScheduled;
   }
 
   @Override

--- a/src/main/java/no/einnsyn/backend/tasks/events/IndexEvent.java
+++ b/src/main/java/no/einnsyn/backend/tasks/events/IndexEvent.java
@@ -9,10 +9,13 @@ public class IndexEvent extends ApplicationEvent {
 
   transient BaseES document;
   boolean insert;
+  boolean updatedSinceLastIndex;
 
-  public IndexEvent(Object source, BaseES document, boolean isInsert) {
+  public IndexEvent(
+      Object source, BaseES document, boolean isInsert, boolean updatedSinceLastIndex) {
     super(source);
     this.document = document;
     this.insert = isInsert;
+    this.updatedSinceLastIndex = updatedSinceLastIndex;
   }
 }

--- a/src/main/java/no/einnsyn/backend/tasks/handlers/subscription/SubscriptionMatcher.java
+++ b/src/main/java/no/einnsyn/backend/tasks/handlers/subscription/SubscriptionMatcher.java
@@ -18,6 +18,7 @@ import no.einnsyn.backend.entities.moetemappe.models.MoetemappeES;
 import no.einnsyn.backend.entities.saksmappe.models.SaksmappeES;
 import no.einnsyn.backend.tasks.events.IndexEvent;
 import no.einnsyn.backend.utils.ElasticsearchIterator;
+import no.einnsyn.backend.utils.TimeConverter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -62,7 +63,7 @@ public class SubscriptionMatcher {
         return;
       }
 
-      if (document instanceof MappeES mappeDocument) {
+      if (document instanceof MappeES mappeDocument && event.isUpdatedSinceLastIndex()) {
         log.debug("Match against Mappe subscriptions: {}", mappeDocument.getId());
         handleSak(mappeDocument);
       }
@@ -86,11 +87,13 @@ public class SubscriptionMatcher {
    * @param mappeDocument the mappe document to match
    */
   private void handleSak(MappeES mappeDocument) {
+    var updated = TimeConverter.timestampToInstant(mappeDocument.getUpdated());
+
     // Update lagretSak where Saksmappe or Moetemappe matches
     if (mappeDocument instanceof SaksmappeES) {
-      lagretSakRepository.addHitBySaksmappe(mappeDocument.getId());
+      lagretSakRepository.addHitBySaksmappe(mappeDocument.getId(), updated);
     } else if (mappeDocument instanceof MoetemappeES) {
-      lagretSakRepository.addHitByMoetemappe(mappeDocument.getId());
+      lagretSakRepository.addHitByMoetemappe(mappeDocument.getId(), updated);
     }
   }
 

--- a/src/test/java/no/einnsyn/backend/tasks/ElasticsearchReindexSchedulerTest.java
+++ b/src/test/java/no/einnsyn/backend/tasks/ElasticsearchReindexSchedulerTest.java
@@ -117,9 +117,9 @@ class ElasticsearchReindexSchedulerTest extends EinnsynLegacyElasticTestBase {
     captureIndexedDocuments(20);
     resetEs();
 
-    // Reindex the stale journalpost and the touched parent saksmappe
+    // Reindex all (one) unindexed documents
     taskTestService.updateOutdatedDocuments();
-    captureIndexedDocuments(2);
+    captureIndexedDocuments(1);
     resetEs();
 
     delete("/arkiv/" + arkivDTO.getId());
@@ -208,9 +208,9 @@ class ElasticsearchReindexSchedulerTest extends EinnsynLegacyElasticTestBase {
     captureIndexedDocuments(20);
     resetEs();
 
-    // Reindex the stale moetesak and the touched parent moetemappe
+    // Reindex all (one) unindexed documents
     taskTestService.updateOutdatedDocuments();
-    captureIndexedDocuments(2);
+    captureIndexedDocuments(1);
     resetEs();
 
     delete("/arkiv/" + arkivDTO.getId());

--- a/src/test/java/no/einnsyn/backend/tasks/ElasticsearchReindexSchedulerTest.java
+++ b/src/test/java/no/einnsyn/backend/tasks/ElasticsearchReindexSchedulerTest.java
@@ -27,7 +27,6 @@ import no.einnsyn.backend.entities.saksmappe.models.SaksmappeDTO;
 import org.json.JSONArray;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.HttpStatus;
@@ -38,9 +37,6 @@ import org.springframework.test.context.ActiveProfiles;
 class ElasticsearchReindexSchedulerTest extends EinnsynLegacyElasticTestBase {
 
   @Autowired TaskTestService taskTestService;
-
-  @Value("${application.elasticsearchReindexBatchSize:20}")
-  private int batchSize;
 
   /**
    * Test that saksmappe that fail to index on creation are reindexed.
@@ -121,9 +117,9 @@ class ElasticsearchReindexSchedulerTest extends EinnsynLegacyElasticTestBase {
     captureIndexedDocuments(20);
     resetEs();
 
-    // Reindex all (one) unindexed documents
+    // Reindex the stale journalpost and the touched parent saksmappe
     taskTestService.updateOutdatedDocuments();
-    captureIndexedDocuments(1);
+    captureIndexedDocuments(2);
     resetEs();
 
     delete("/arkiv/" + arkivDTO.getId());
@@ -212,9 +208,9 @@ class ElasticsearchReindexSchedulerTest extends EinnsynLegacyElasticTestBase {
     captureIndexedDocuments(20);
     resetEs();
 
-    // Reindex all (one) unindexed documents
+    // Reindex the stale moetesak and the touched parent moetemappe
     taskTestService.updateOutdatedDocuments();
-    captureIndexedDocuments(1);
+    captureIndexedDocuments(2);
     resetEs();
 
     delete("/arkiv/" + arkivDTO.getId());

--- a/src/test/java/no/einnsyn/backend/tasks/LagretSakSubscriptionTest.java
+++ b/src/test/java/no/einnsyn/backend/tasks/LagretSakSubscriptionTest.java
@@ -2,10 +2,15 @@ package no.einnsyn.backend.tasks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import jakarta.mail.internet.MimeMessage;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.function.Function;
 import no.einnsyn.backend.EinnsynLegacyElasticTestBase;
 import no.einnsyn.backend.authentication.bruker.models.TokenResponse;
 import no.einnsyn.backend.entities.arkiv.models.ArkivDTO;
@@ -14,6 +19,7 @@ import no.einnsyn.backend.entities.bruker.models.BrukerDTO;
 import no.einnsyn.backend.entities.lagretsak.models.LagretSakDTO;
 import no.einnsyn.backend.entities.moetemappe.models.MoetemappeDTO;
 import no.einnsyn.backend.entities.saksmappe.models.SaksmappeDTO;
+import no.einnsyn.backend.tasks.handlers.reindex.ElasticsearchReindexScheduler;
 import org.awaitility.Awaitility;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
@@ -24,12 +30,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
 
   @Autowired TaskTestService taskTestService;
+  @Autowired ElasticsearchReindexScheduler elasticsearchReindexScheduler;
 
   ArkivDTO arkivDTO;
   ArkivdelDTO arkivdelDTO;
@@ -131,6 +139,111 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
     assertEquals(0, taskTestService.getLagretSakHitCount(lagretSakDTO.getId()));
 
     // Delete the Saksmappe
+    response = delete("/saksmappe/" + saksmappeDTO.getId());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    captureDeletedDocuments(2);
+  }
+
+  @Test
+  void testLagretSaksmappeSubscriptionIgnoresBackgroundReindex() throws Exception {
+    // Create a Saksmappe
+    var saksmappeJSON = getSaksmappeJSON();
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", saksmappeJSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var saksmappeDTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
+
+    captureIndexedDocuments(1);
+    resetEs();
+
+    // Create a lagretSak subscription for the Saksmappe
+    var lagretSakJSON = getLagretSakJSON();
+    lagretSakJSON.put("saksmappe", saksmappeDTO.getId());
+    response = post("/bruker/" + brukerDTO.getId() + "/lagretSak", lagretSakJSON, accessToken);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var lagretSakDTO = gson.fromJson(response.getBody(), LagretSakDTO.class);
+
+    // Force a background reindex through the schema-version path without changing the row.
+    var originalSchemaTimestamp =
+        (Instant)
+            ReflectionTestUtils.getField(
+                elasticsearchReindexScheduler, "saksmappeSchemaTimestamp");
+    ReflectionTestUtils.setField(
+        elasticsearchReindexScheduler,
+        "saksmappeSchemaTimestamp",
+        Instant.now().plusSeconds(3600));
+
+    try {
+      taskTestService.updateOutdatedDocuments();
+      captureIndexedDocuments(1);
+      resetEs();
+
+      // Background reindexing should not create LagretSak hits or emails.
+      assertEquals(0, taskTestService.getLagretSakHitCount(lagretSakDTO.getId()));
+
+      taskTestService.notifyLagretSak();
+      verify(javaMailSender, never()).send(any(MimeMessage.class));
+    } finally {
+      ReflectionTestUtils.setField(
+          elasticsearchReindexScheduler, "saksmappeSchemaTimestamp", originalSchemaTimestamp);
+    }
+
+    response = delete("/lagretSak/" + lagretSakDTO.getId(), accessToken);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+
+    response = delete("/saksmappe/" + saksmappeDTO.getId());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    captureDeletedDocuments(1);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void testLagretSaksmappeSubscriptionReplaysFailedChildWrite() throws Exception {
+    // Create a Saksmappe
+    var saksmappeJSON = getSaksmappeJSON();
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", saksmappeJSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var saksmappeDTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
+
+    captureIndexedDocuments(1);
+    resetEs();
+
+    // Create a lagretSak subscription before the child write happens.
+    var lagretSakJSON = getLagretSakJSON();
+    lagretSakJSON.put("saksmappe", saksmappeDTO.getId());
+    response = post("/bruker/" + brukerDTO.getId() + "/lagretSak", lagretSakJSON, accessToken);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var lagretSakDTO = gson.fromJson(response.getBody(), LagretSakDTO.class);
+
+    // Fail both index operations caused by adding a Journalpost (child + parent).
+    doThrow(new IOException("Failed to index document"))
+        .doThrow(new IOException("Failed to index document"))
+        .doCallRealMethod()
+        .when(esClient)
+        .index(any(Function.class));
+
+    response = post("/saksmappe/" + saksmappeDTO.getId() + "/journalpost", getJournalpostJSON());
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+
+    captureIndexedDocuments(2);
+    resetEs();
+
+    // The failed request-end indexing should not have produced any hit yet.
+    assertEquals(0, taskTestService.getLagretSakHitCount(lagretSakDTO.getId()));
+
+    // The scheduler should replay the missed child write and notify the subscription.
+    taskTestService.updateOutdatedDocuments();
+    captureIndexedDocuments(2);
+    resetEs();
+
+    assertEquals(1, taskTestService.getLagretSakHitCount(lagretSakDTO.getId()));
+
+    taskTestService.notifyLagretSak();
+    Awaitility.await()
+        .untilAsserted(() -> verify(javaMailSender, times(1)).send(any(MimeMessage.class)));
+
+    response = delete("/lagretSak/" + lagretSakDTO.getId(), accessToken);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+
     response = delete("/saksmappe/" + saksmappeDTO.getId());
     assertEquals(HttpStatus.OK, response.getStatusCode());
     captureDeletedDocuments(2);

--- a/src/test/java/no/einnsyn/backend/tasks/LagretSakSubscriptionTest.java
+++ b/src/test/java/no/einnsyn/backend/tasks/LagretSakSubscriptionTest.java
@@ -38,10 +38,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ActiveProfiles("test")
 class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
 
-  @Autowired
-  TaskTestService taskTestService;
-  @Autowired
-  ElasticsearchReindexScheduler elasticsearchReindexScheduler;
+  @Autowired TaskTestService taskTestService;
+  @Autowired ElasticsearchReindexScheduler elasticsearchReindexScheduler;
 
   ArkivDTO arkivDTO;
   ArkivdelDTO arkivdelDTO;
@@ -157,9 +155,9 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
     assertEquals(HttpStatus.CREATED, response.getStatusCode());
     var saksmappeDTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
     response = get("/saksmappe/" + saksmappeDTO.getId() + "/journalpost");
-    var resultListType = new TypeToken<PaginatedList<JournalpostDTO>>() {
-    }.getType();
-    PaginatedList<JournalpostDTO> journalpostDTOList = gson.fromJson(response.getBody(), resultListType);
+    var resultListType = new TypeToken<PaginatedList<JournalpostDTO>>() {}.getType();
+    PaginatedList<JournalpostDTO> journalpostDTOList =
+        gson.fromJson(response.getBody(), resultListType);
     var journalpostDTO = journalpostDTOList.getItems().getFirst();
 
     captureIndexedDocuments(2);
@@ -186,8 +184,9 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
 
     // Force a background reindex through the schema-version path without changing
     // the row.
-    var originalSchemaTimestamp = (Instant) ReflectionTestUtils.getField(elasticsearchReindexScheduler,
-        "saksmappeSchemaTimestamp");
+    var originalSchemaTimestamp =
+        (Instant)
+            ReflectionTestUtils.getField(elasticsearchReindexScheduler, "saksmappeSchemaTimestamp");
     ReflectionTestUtils.setField(
         elasticsearchReindexScheduler, "saksmappeSchemaTimestamp", Instant.now().plusSeconds(3600));
 
@@ -248,8 +247,10 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
 
     // Force a background reindex through the schema-version path without changing
     // the row.
-    var originalSchemaTimestamp = (Instant) ReflectionTestUtils.getField(
-        elasticsearchReindexScheduler, "moetemappeSchemaTimestamp");
+    var originalSchemaTimestamp =
+        (Instant)
+            ReflectionTestUtils.getField(
+                elasticsearchReindexScheduler, "moetemappeSchemaTimestamp");
     ReflectionTestUtils.setField(
         elasticsearchReindexScheduler,
         "moetemappeSchemaTimestamp",

--- a/src/test/java/no/einnsyn/backend/tasks/LagretSakSubscriptionTest.java
+++ b/src/test/java/no/einnsyn/backend/tasks/LagretSakSubscriptionTest.java
@@ -17,6 +17,7 @@ import no.einnsyn.backend.entities.arkivdel.models.ArkivdelDTO;
 import no.einnsyn.backend.entities.bruker.models.BrukerDTO;
 import no.einnsyn.backend.entities.journalpost.models.JournalpostDTO;
 import no.einnsyn.backend.entities.lagretsak.models.LagretSakDTO;
+import no.einnsyn.backend.entities.moetedokument.models.MoetedokumentDTO;
 import no.einnsyn.backend.entities.moetemappe.models.MoetemappeDTO;
 import no.einnsyn.backend.entities.saksmappe.models.SaksmappeDTO;
 import no.einnsyn.backend.tasks.handlers.reindex.ElasticsearchReindexScheduler;
@@ -207,6 +208,118 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
     assertEquals(HttpStatus.OK, response.getStatusCode());
 
     response = delete("/saksmappe/" + saksmappeDTO.getId());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    captureDeletedDocuments(2);
+  }
+
+  @Test
+  void testLagretMoetemappeSubscriptionIgnoresBackgroundReindex() throws Exception {
+    // Create a Moetemappe (default JSON includes one moetesak)
+    var moetemappeJSON = getMoetemappeJSON();
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/moetemappe", moetemappeJSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var moetemappeDTO = gson.fromJson(response.getBody(), MoetemappeDTO.class);
+    var moetesakId = moetemappeDTO.getMoetesak().get(0).getId();
+
+    captureIndexedDocuments(2); // moetemappe + moetesak
+    resetEs();
+
+    // Subscribe to the Moetemappe
+    var lagretSakJSON = getLagretSakJSON();
+    lagretSakJSON.put("moetemappe", moetemappeDTO.getId());
+    response = post("/bruker/" + brukerDTO.getId() + "/lagretSak", lagretSakJSON, accessToken);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var lagretSakDTO = gson.fromJson(response.getBody(), LagretSakDTO.class);
+
+    // Update the moetesak — cascade should bump moetemappe.updated and trigger a hit
+    var updateJSON = new JSONObject();
+    updateJSON.put("offentligTittel", "new title");
+    response = patch("/moetesak/" + moetesakId, updateJSON);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(1, taskTestService.getLagretSakHitCount(lagretSakDTO.getId()));
+    taskTestService.notifyLagretSak();
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+    resetMail();
+    captureIndexedDocuments(2); // moetesak + moetemappe
+    resetEs();
+
+    // Force a background reindex through the schema-version path without changing
+    // the row.
+    var originalSchemaTimestamp =
+        (Instant)
+            ReflectionTestUtils.getField(
+                elasticsearchReindexScheduler, "moetemappeSchemaTimestamp");
+    ReflectionTestUtils.setField(
+        elasticsearchReindexScheduler,
+        "moetemappeSchemaTimestamp",
+        Instant.now().plusSeconds(3600));
+
+    try {
+      taskTestService.updateOutdatedDocuments();
+      captureIndexedDocuments(1); // only moetemappe is touched by the schema bump
+      resetEs();
+
+      // Background reindexing should not create LagretSak hits or emails.
+      assertEquals(0, taskTestService.getLagretSakHitCount(lagretSakDTO.getId()));
+
+      taskTestService.notifyLagretSak();
+      verify(javaMailSender, never()).send(any(MimeMessage.class));
+    } finally {
+      ReflectionTestUtils.setField(
+          elasticsearchReindexScheduler, "moetemappeSchemaTimestamp", originalSchemaTimestamp);
+    }
+
+    response = delete("/lagretSak/" + lagretSakDTO.getId(), accessToken);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+
+    response = delete("/moetemappe/" + moetemappeDTO.getId());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    captureDeletedDocuments(2);
+  }
+
+  @Test
+  void testKorrespondansepartChangeFiresMoetemappeSubscription() throws Exception {
+    // Create a Moetemappe (default JSON includes moetedokuments with korrespondanseparts)
+    var moetemappeJSON = getMoetemappeJSON();
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/moetemappe", moetemappeJSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var moetemappeDTO = gson.fromJson(response.getBody(), MoetemappeDTO.class);
+
+    // Resolve a korrespondansepart attached to the first moetedokument
+    var moetedokumentId = moetemappeDTO.getMoetedokument().get(0).getId();
+    response = get("/moetedokument/" + moetedokumentId);
+    var moetedokumentDTO = gson.fromJson(response.getBody(), MoetedokumentDTO.class);
+    var korrespondansepartId = moetedokumentDTO.getKorrespondansepart().get(0).getId();
+
+    captureIndexedDocuments(2); // moetemappe + moetesak
+    resetEs();
+
+    // Subscribe to the Moetemappe
+    var lagretSakJSON = getLagretSakJSON();
+    lagretSakJSON.put("moetemappe", moetemappeDTO.getId());
+    response = post("/bruker/" + brukerDTO.getId() + "/lagretSak", lagretSakJSON, accessToken);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var lagretSakDTO = gson.fromJson(response.getBody(), LagretSakDTO.class);
+
+    // Update the korrespondansepart. Korrespondansepart and Moetedokument are not
+    // Indexable themselves, so the change must cascade through Moetedokument and
+    // touchUpdated() the Moetemappe to fire its subscription.
+    var updateJSON = new JSONObject();
+    updateJSON.put("korrespondansepartNavn", "updated navn");
+    response = patch("/korrespondansepart/" + korrespondansepartId, updateJSON);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+
+    assertEquals(1, taskTestService.getLagretSakHitCount(lagretSakDTO.getId()));
+    taskTestService.notifyLagretSak();
+    Awaitility.await()
+        .untilAsserted(() -> verify(javaMailSender, times(1)).send(any(MimeMessage.class)));
+    captureIndexedDocuments(1); // only moetemappe is reindexed
+    resetEs();
+
+    response = delete("/lagretSak/" + lagretSakDTO.getId(), accessToken);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+
+    response = delete("/moetemappe/" + moetemappeDTO.getId());
     assertEquals(HttpStatus.OK, response.getStatusCode());
     captureDeletedDocuments(2);
   }

--- a/src/test/java/no/einnsyn/backend/tasks/LagretSakSubscriptionTest.java
+++ b/src/test/java/no/einnsyn/backend/tasks/LagretSakSubscriptionTest.java
@@ -2,25 +2,26 @@ package no.einnsyn.backend.tasks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.google.gson.reflect.TypeToken;
 import jakarta.mail.internet.MimeMessage;
-import java.io.IOException;
 import java.time.Instant;
-import java.util.function.Function;
 import no.einnsyn.backend.EinnsynLegacyElasticTestBase;
 import no.einnsyn.backend.authentication.bruker.models.TokenResponse;
+import no.einnsyn.backend.common.responses.models.PaginatedList;
 import no.einnsyn.backend.entities.arkiv.models.ArkivDTO;
 import no.einnsyn.backend.entities.arkivdel.models.ArkivdelDTO;
 import no.einnsyn.backend.entities.bruker.models.BrukerDTO;
+import no.einnsyn.backend.entities.journalpost.models.JournalpostDTO;
 import no.einnsyn.backend.entities.lagretsak.models.LagretSakDTO;
 import no.einnsyn.backend.entities.moetemappe.models.MoetemappeDTO;
 import no.einnsyn.backend.entities.saksmappe.models.SaksmappeDTO;
 import no.einnsyn.backend.tasks.handlers.reindex.ElasticsearchReindexScheduler;
 import org.awaitility.Awaitility;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -148,11 +149,17 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
   void testLagretSaksmappeSubscriptionIgnoresBackgroundReindex() throws Exception {
     // Create a Saksmappe
     var saksmappeJSON = getSaksmappeJSON();
+    saksmappeJSON.put("journalpost", new JSONArray().put(getJournalpostJSON()));
     var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", saksmappeJSON);
     assertEquals(HttpStatus.CREATED, response.getStatusCode());
     var saksmappeDTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
+    response = get("/saksmappe/" + saksmappeDTO.getId() + "/journalpost");
+    var resultListType = new TypeToken<PaginatedList<JournalpostDTO>>() {}.getType();
+    PaginatedList<JournalpostDTO> journalpostDTOList =
+        gson.fromJson(response.getBody(), resultListType);
+    var journalpostDTO = journalpostDTOList.getItems().getFirst();
 
-    captureIndexedDocuments(1);
+    captureIndexedDocuments(2);
     resetEs();
 
     // Create a lagretSak subscription for the Saksmappe
@@ -162,15 +169,24 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
     assertEquals(HttpStatus.CREATED, response.getStatusCode());
     var lagretSakDTO = gson.fromJson(response.getBody(), LagretSakDTO.class);
 
-    // Force a background reindex through the schema-version path without changing the row.
+    // Update the journalpost, should trigger LagretSak hit
+    var updateJSON = new JSONObject();
+    updateJSON.put("offentligTittel", "new title");
+    response = patch("/journalpost/" + journalpostDTO.getId(), updateJSON);
+    assertEquals(1, taskTestService.getLagretSakHitCount(lagretSakDTO.getId()));
+    taskTestService.notifyLagretSak();
+    verify(javaMailSender, times(1)).send(any(MimeMessage.class));
+    resetMail();
+    captureIndexedDocuments(2);
+    resetEs();
+
+    // Force a background reindex through the schema-version path without changing
+    // the row.
     var originalSchemaTimestamp =
         (Instant)
-            ReflectionTestUtils.getField(
-                elasticsearchReindexScheduler, "saksmappeSchemaTimestamp");
+            ReflectionTestUtils.getField(elasticsearchReindexScheduler, "saksmappeSchemaTimestamp");
     ReflectionTestUtils.setField(
-        elasticsearchReindexScheduler,
-        "saksmappeSchemaTimestamp",
-        Instant.now().plusSeconds(3600));
+        elasticsearchReindexScheduler, "saksmappeSchemaTimestamp", Instant.now().plusSeconds(3600));
 
     try {
       taskTestService.updateOutdatedDocuments();
@@ -186,60 +202,6 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
       ReflectionTestUtils.setField(
           elasticsearchReindexScheduler, "saksmappeSchemaTimestamp", originalSchemaTimestamp);
     }
-
-    response = delete("/lagretSak/" + lagretSakDTO.getId(), accessToken);
-    assertEquals(HttpStatus.OK, response.getStatusCode());
-
-    response = delete("/saksmappe/" + saksmappeDTO.getId());
-    assertEquals(HttpStatus.OK, response.getStatusCode());
-    captureDeletedDocuments(1);
-  }
-
-  @SuppressWarnings("unchecked")
-  @Test
-  void testLagretSaksmappeSubscriptionReplaysFailedChildWrite() throws Exception {
-    // Create a Saksmappe
-    var saksmappeJSON = getSaksmappeJSON();
-    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", saksmappeJSON);
-    assertEquals(HttpStatus.CREATED, response.getStatusCode());
-    var saksmappeDTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
-
-    captureIndexedDocuments(1);
-    resetEs();
-
-    // Create a lagretSak subscription before the child write happens.
-    var lagretSakJSON = getLagretSakJSON();
-    lagretSakJSON.put("saksmappe", saksmappeDTO.getId());
-    response = post("/bruker/" + brukerDTO.getId() + "/lagretSak", lagretSakJSON, accessToken);
-    assertEquals(HttpStatus.CREATED, response.getStatusCode());
-    var lagretSakDTO = gson.fromJson(response.getBody(), LagretSakDTO.class);
-
-    // Fail both index operations caused by adding a Journalpost (child + parent).
-    doThrow(new IOException("Failed to index document"))
-        .doThrow(new IOException("Failed to index document"))
-        .doCallRealMethod()
-        .when(esClient)
-        .index(any(Function.class));
-
-    response = post("/saksmappe/" + saksmappeDTO.getId() + "/journalpost", getJournalpostJSON());
-    assertEquals(HttpStatus.CREATED, response.getStatusCode());
-
-    captureIndexedDocuments(2);
-    resetEs();
-
-    // The failed request-end indexing should not have produced any hit yet.
-    assertEquals(0, taskTestService.getLagretSakHitCount(lagretSakDTO.getId()));
-
-    // The scheduler should replay the missed child write and notify the subscription.
-    taskTestService.updateOutdatedDocuments();
-    captureIndexedDocuments(2);
-    resetEs();
-
-    assertEquals(1, taskTestService.getLagretSakHitCount(lagretSakDTO.getId()));
-
-    taskTestService.notifyLagretSak();
-    Awaitility.await()
-        .untilAsserted(() -> verify(javaMailSender, times(1)).send(any(MimeMessage.class)));
 
     response = delete("/lagretSak/" + lagretSakDTO.getId(), accessToken);
     assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/src/test/java/no/einnsyn/backend/tasks/LagretSakSubscriptionTest.java
+++ b/src/test/java/no/einnsyn/backend/tasks/LagretSakSubscriptionTest.java
@@ -38,8 +38,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ActiveProfiles("test")
 class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
 
-  @Autowired TaskTestService taskTestService;
-  @Autowired ElasticsearchReindexScheduler elasticsearchReindexScheduler;
+  @Autowired
+  TaskTestService taskTestService;
+  @Autowired
+  ElasticsearchReindexScheduler elasticsearchReindexScheduler;
 
   ArkivDTO arkivDTO;
   ArkivdelDTO arkivdelDTO;
@@ -155,9 +157,9 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
     assertEquals(HttpStatus.CREATED, response.getStatusCode());
     var saksmappeDTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
     response = get("/saksmappe/" + saksmappeDTO.getId() + "/journalpost");
-    var resultListType = new TypeToken<PaginatedList<JournalpostDTO>>() {}.getType();
-    PaginatedList<JournalpostDTO> journalpostDTOList =
-        gson.fromJson(response.getBody(), resultListType);
+    var resultListType = new TypeToken<PaginatedList<JournalpostDTO>>() {
+    }.getType();
+    PaginatedList<JournalpostDTO> journalpostDTOList = gson.fromJson(response.getBody(), resultListType);
     var journalpostDTO = journalpostDTOList.getItems().getFirst();
 
     captureIndexedDocuments(2);
@@ -174,6 +176,7 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
     var updateJSON = new JSONObject();
     updateJSON.put("offentligTittel", "new title");
     response = patch("/journalpost/" + journalpostDTO.getId(), updateJSON);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
     assertEquals(1, taskTestService.getLagretSakHitCount(lagretSakDTO.getId()));
     taskTestService.notifyLagretSak();
     verify(javaMailSender, times(1)).send(any(MimeMessage.class));
@@ -183,9 +186,8 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
 
     // Force a background reindex through the schema-version path without changing
     // the row.
-    var originalSchemaTimestamp =
-        (Instant)
-            ReflectionTestUtils.getField(elasticsearchReindexScheduler, "saksmappeSchemaTimestamp");
+    var originalSchemaTimestamp = (Instant) ReflectionTestUtils.getField(elasticsearchReindexScheduler,
+        "saksmappeSchemaTimestamp");
     ReflectionTestUtils.setField(
         elasticsearchReindexScheduler, "saksmappeSchemaTimestamp", Instant.now().plusSeconds(3600));
 
@@ -231,7 +233,8 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
     assertEquals(HttpStatus.CREATED, response.getStatusCode());
     var lagretSakDTO = gson.fromJson(response.getBody(), LagretSakDTO.class);
 
-    // Update the moetesak — cascade should bump moetemappe.updated and trigger a hit
+    // Update the moetesak — cascade should bump moetemappe.updated and trigger a
+    // hit
     var updateJSON = new JSONObject();
     updateJSON.put("offentligTittel", "new title");
     response = patch("/moetesak/" + moetesakId, updateJSON);
@@ -245,10 +248,8 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
 
     // Force a background reindex through the schema-version path without changing
     // the row.
-    var originalSchemaTimestamp =
-        (Instant)
-            ReflectionTestUtils.getField(
-                elasticsearchReindexScheduler, "moetemappeSchemaTimestamp");
+    var originalSchemaTimestamp = (Instant) ReflectionTestUtils.getField(
+        elasticsearchReindexScheduler, "moetemappeSchemaTimestamp");
     ReflectionTestUtils.setField(
         elasticsearchReindexScheduler,
         "moetemappeSchemaTimestamp",
@@ -279,7 +280,8 @@ class LagretSakSubscriptionTest extends EinnsynLegacyElasticTestBase {
 
   @Test
   void testKorrespondansepartChangeFiresMoetemappeSubscription() throws Exception {
-    // Create a Moetemappe (default JSON includes moetedokuments with korrespondanseparts)
+    // Create a Moetemappe (default JSON includes moetedokuments with
+    // korrespondanseparts)
     var moetemappeJSON = getMoetemappeJSON();
     var response = post("/arkivdel/" + arkivdelDTO.getId() + "/moetemappe", moetemappeJSON);
     assertEquals(HttpStatus.CREATED, response.getStatusCode());


### PR DESCRIPTION
This PR prevents subscription alerts from firing on Mappe reindexing.

- IndexEvent now has an updatedSinceLastIndex flag so consumers can distinguish real updates from reindex events.
- SubscriptionMatcher only matches Mappe subscriptions when that flag is set, and now passes the document's updated timestamp to lagretSakRepository.addHitBy{Saksmappe,Moetemappe} to filter hits.