### PR TITLE
fix(datasource): set Postgres socketTimeout to prevent connections blocking forever (EIN-5004)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -123,6 +123,9 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME}
     password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      data-source-properties:
+        socketTimeout: 30
   http:
     converters.preferred-json-mapper: gson
   mvc:


### PR DESCRIPTION
If a read-query doesn't respond within 30 seconds (broken connection, restarted load balancer etc.), free the connection.

- This will also affect flyway. `CREATE INDEX` etc. won't work on big tables, they must be added manually.
- Long running streams (reindexer etc.) will work.