### PR TITLE
chore: Don't run tests during container scan

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -57,4 +57,5 @@ jobs:
     with:
       java-version: 25
       trivy-os-disable-scan: true
+      maven-skip-tests: true
     secrets: inherit


### PR DESCRIPTION
The common workflows have been updated, and the container scan will default to running the tests before building the image unless we explicitly pass the skip-tests-flag