### PR TITLE
EIN-5003: Force preemptive auth against ES

### DIFF
--- a/src/main/java/no/einnsyn/backend/configuration/ElasticsearchConfiguration.java
+++ b/src/main/java/no/einnsyn/backend/configuration/ElasticsearchConfiguration.java
@@ -2,10 +2,19 @@ package no.einnsyn.backend.configuration;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import jakarta.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import no.einnsyn.backend.tasks.handlers.index.ElasticsearchHandlerInterceptor;
 import no.einnsyn.backend.utils.ElasticsearchIndexCreator;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.elasticsearch.autoconfigure.ElasticsearchConnectionDetails;
+import org.springframework.boot.elasticsearch.autoconfigure.Rest5ClientBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -26,6 +35,28 @@ public class ElasticsearchConfiguration implements WebMvcConfigurer {
     this.elasticsearchClient = elasticsearchClient;
     this.elasticsearchIndex = elasticsearchIndex;
     this.percolatorIndex = percolatorIndex;
+  }
+
+  /**
+   * Send credentials preemptively instead of waiting for a 401 challenge.
+   *
+   * <p>Static because this class injects the ElasticsearchClient, which must be built after this
+   * customizer.
+   */
+  @Bean
+  static Rest5ClientBuilderCustomizer preemptiveAuthCustomizer(
+      ElasticsearchConnectionDetails connectionDetails) {
+    // Only set the auth header if we have credentials to use
+    if (StringUtils.hasText(connectionDetails.getUsername())) {
+      var token =
+          Base64.getEncoder()
+              .encodeToString(
+                  (connectionDetails.getUsername() + ":" + connectionDetails.getPassword())
+                      .getBytes(StandardCharsets.UTF_8));
+      var authHeader = new BasicHeader(HttpHeaders.AUTHORIZATION, "Basic " + token);
+      return builder -> builder.setDefaultHeaders(new Header[] {authHeader});
+    }
+    return _ -> {};
   }
 
   @PostConstruct

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -144,8 +144,8 @@ spring:
     virtual.enabled: true
   elasticsearch:
     uris: ${application.elasticsearch.uri}
-    username: ${SPRING_ELASTICSEARCH_USERNAME}
-    password: ${SPRING_ELASTICSEARCH_PASSWORD}
+    username: ${SPRING_ELASTICSEARCH_USERNAME:}
+    password: ${SPRING_ELASTICSEARCH_PASSWORD:}
 management:
   server:
     port: 8090


### PR DESCRIPTION
By default Spring Boot configures the ES-Client to always attempt an unauthenticated request and only provide credentials when challenged with a 401 response.

This seems pointless. If the app is configured with credentials, they should always be used.