### PR TITLE
fix: Require ROOT_API_KEY and JWT_SECRET, with no insecure defaults (EIN-5010)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,18 @@ The following services are required to run the application:
 - PostgreSQL
 - E-mail server
 
+`ROOT_API_KEY` and `JWT_SECRET` have no defaults, and the application refuses to start without
+them. Both are administrator-equivalent: the root API key authenticates as an administrator, and
+the JWT secret is a symmetric HMAC key, so it both verifies and mints tokens. Generate them with
+`openssl rand -base64 32`, and put them in a git-ignored `.env` file in the project root, which is
+imported at startup.
+
 ### Environment variables (and their default values)
 
 ```
 # Application settings
 BASE_URL=http://localhost:8080
-ROOT_API_KEY=
+ROOT_API_KEY=<required, no default>
 
 # PostgreSQL settings
 SPRING_DATASOURCE_URL=jdbc:postgresql://localhost/arkiv
@@ -71,7 +77,7 @@ EMAIL_FROM=eInnsyn.no <test@example.com>
 EMAIL_FROM_HOST=example.com
 
 # Authentication settings
-JWT_SECRET=
+JWT_SECRET=<required, no default>
 JWT_REFRESH_EXPIRATION=
 
 # Elasticsearch reindex settings

--- a/README.md
+++ b/README.md
@@ -50,12 +50,19 @@ the JWT secret is a symmetric HMAC key, so it both verifies and mints tokens. Ge
 `openssl rand -base64 32`, and put them in a git-ignored `.env` file in the project root, which is
 imported at startup.
 
+`ROOT_API_KEY` is only read by the baseline migration, which seeds it as the secret of the root API
+key when initializing an empty database. Setting or changing it against an already migrated database
+has no effect: rotate that credential by creating a replacement through `POST /enhet/{id}/apiKey`,
+then removing the old one through `DELETE /apiKey/{id}`. The value must not contain a single quote,
+as the migration interpolates it into a quoted SQL literal.
+
 ### Environment variables (and their default values)
 
 ```
 # Application settings
 BASE_URL=http://localhost:8080
-ROOT_API_KEY=<required, no default>
+# ROOT_API_KEY is required, no default. Generate with `openssl rand -base64 32`.
+ROOT_API_KEY=
 
 # PostgreSQL settings
 SPRING_DATASOURCE_URL=jdbc:postgresql://localhost/arkiv
@@ -77,7 +84,8 @@ EMAIL_FROM=eInnsyn.no <test@example.com>
 EMAIL_FROM_HOST=example.com
 
 # Authentication settings
-JWT_SECRET=<required, no default>
+# JWT_SECRET is required, no default. Generate with `openssl rand -base64 32`.
+JWT_SECRET=
 JWT_REFRESH_EXPIRATION=
 
 # Elasticsearch reindex settings

--- a/src/main/java/no/einnsyn/backend/authentication/bruker/EInnsynJwtConfiguration.java
+++ b/src/main/java/no/einnsyn/backend/authentication/bruker/EInnsynJwtConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
 import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.util.Assert;
 
 @Configuration
 @Slf4j
@@ -35,7 +36,16 @@ public class EInnsynJwtConfiguration {
   public EInnsynJwtConfiguration(
       @Value("${application.jwt.encryption-secret}") String base64Secret,
       @Value("${application.jwt.issuerUri}") String issuerUri) {
-    this.decodedSecretBytes = Base64.getDecoder().decode(base64Secret);
+    Assert.hasText(
+        base64Secret, "application.jwt.encryption-secret (JWT_SECRET) must not be empty");
+    var secretBytes = Base64.getDecoder().decode(base64Secret);
+    // HS256 needs a 256 bit key. Without this check, a shorter secret starts the application, and
+    // only fails later when Nimbus is asked to sign or verify a token.
+    Assert.isTrue(
+        secretBytes.length >= 32,
+        "application.jwt.encryption-secret (JWT_SECRET) must decode to at least 256 bits."
+            + " Generate one with `openssl rand -base64 32`");
+    this.decodedSecretBytes = secretBytes;
     this.issuerUri = issuerUri;
   }
 

--- a/src/main/java/no/einnsyn/backend/configuration/FlywayConfiguration.java
+++ b/src/main/java/no/einnsyn/backend/configuration/FlywayConfiguration.java
@@ -11,17 +11,8 @@ import org.springframework.util.Assert;
 public class FlywayConfiguration {
 
   /**
-   * Supplies the root API key secret to the baseline migration, which seeds it as the secret of the
-   * root API key. The root Enhet has no parent, so that key authenticates as an administrator. Only
-   * the baseline migration reads this value, so it has no effect against an already migrated
-   * database.
-   *
-   * <p>This is deliberately not wired through {@code spring.flyway.placeholders} in
-   * application.yml: the configuration property binder leaves placeholders it cannot resolve as
-   * literal text, so with {@code ROOT_API_KEY} unset, the yml route seeds {@code
-   * sha256("${ROOT_API_KEY}")} — a working administrator credential that anyone reading this
-   * repository could present. A {@code @Value} parameter resolves strictly instead, and fails while
-   * the Flyway bean is being built, before any migration runs.
+   * Validate that the fallback API key is set and does not contain a single quote, and add it to
+   * the Flyway placeholders so that it can be used in the baseline migration.
    */
   @Bean
   FlywayConfigurationCustomizer rootApiKeyPlaceholder(

--- a/src/main/java/no/einnsyn/backend/configuration/FlywayConfiguration.java
+++ b/src/main/java/no/einnsyn/backend/configuration/FlywayConfiguration.java
@@ -1,0 +1,30 @@
+package no.einnsyn.backend.configuration;
+
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.flyway.autoconfigure.FlywayConfigurationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
+
+@Configuration
+public class FlywayConfiguration {
+
+  /**
+   * Supplies the root API key secret to the baseline migration, which seeds it as the secret of the
+   * root API key. The root Enhet has no parent, so that key authenticates as an administrator.
+   *
+   * <p>This is deliberately not wired through {@code spring.flyway.placeholders} in
+   * application.yml: the configuration property binder leaves placeholders it cannot resolve as
+   * literal text, so with {@code ROOT_API_KEY} unset, the yml route seeds {@code
+   * sha256("${ROOT_API_KEY}")} — a working administrator credential that anyone reading this
+   * repository could present. A {@code @Value} parameter resolves strictly instead, and fails while
+   * the Flyway bean is being built, before any migration runs.
+   */
+  @Bean
+  FlywayConfigurationCustomizer rootApiKeyPlaceholder(
+      @Value("${application.apikey.root-key}") String rootApiKey) {
+    Assert.hasText(rootApiKey, "application.apikey.root-key (ROOT_API_KEY) must not be empty");
+    return configuration -> configuration.placeholders(Map.of("apikey-root-key", rootApiKey));
+  }
+}

--- a/src/main/java/no/einnsyn/backend/configuration/FlywayConfiguration.java
+++ b/src/main/java/no/einnsyn/backend/configuration/FlywayConfiguration.java
@@ -1,6 +1,6 @@
 package no.einnsyn.backend.configuration;
 
-import java.util.Map;
+import java.util.HashMap;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.flyway.autoconfigure.FlywayConfigurationCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -12,7 +12,9 @@ public class FlywayConfiguration {
 
   /**
    * Supplies the root API key secret to the baseline migration, which seeds it as the secret of the
-   * root API key. The root Enhet has no parent, so that key authenticates as an administrator.
+   * root API key. The root Enhet has no parent, so that key authenticates as an administrator. Only
+   * the baseline migration reads this value, so it has no effect against an already migrated
+   * database.
    *
    * <p>This is deliberately not wired through {@code spring.flyway.placeholders} in
    * application.yml: the configuration property binder leaves placeholders it cannot resolve as
@@ -25,6 +27,17 @@ public class FlywayConfiguration {
   FlywayConfigurationCustomizer rootApiKeyPlaceholder(
       @Value("${application.apikey.root-key}") String rootApiKey) {
     Assert.hasText(rootApiKey, "application.apikey.root-key (ROOT_API_KEY) must not be empty");
-    return configuration -> configuration.placeholders(Map.of("apikey-root-key", rootApiKey));
+    Assert.doesNotContain(
+        rootApiKey,
+        "'",
+        "application.apikey.root-key (ROOT_API_KEY) must not contain a single quote, as it is"
+            + " interpolated into a quoted SQL literal in the baseline migration");
+    return configuration -> {
+      // Merge rather than replace: Spring Boot has already applied spring.flyway.placeholders by
+      // the time customizers run, and placeholders(Map) overwrites the whole map.
+      var placeholders = new HashMap<>(configuration.getPlaceholders());
+      placeholders.put("apikey-root-key", rootApiKey);
+      configuration.placeholders(placeholders);
+    };
   }
 }

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -63,7 +63,7 @@
 		{
 			"name": "application.jwt.encryption-secret",
 			"type": "java.lang.String",
-			"description": "JWT Secret. This must be a 256 bit HMAC hash in base64 encoding. Generate using `openssl rand -base64 32`"
+			"description": "JWT Secret. Required, no default. This must be a 256 bit HMAC hash in base64 encoding. Generate using `openssl rand -base64 32`"
 		},
 		{
 			"name": "application.jwt.accessTokenExpiration",
@@ -78,12 +78,7 @@
 		{
 			"name": "application.apikey.root-key",
 			"type": "java.lang.String",
-			"description": "ID of the root API key."
-		},
-		{
-			"name": "application.apikey.root-secret",
-			"type": "java.lang.String",
-			"description": "Default root API secret. This is used to initialize a fresh database, and may be changed later."
+			"description": "Secret of the root API key, which authenticates as an administrator. Required, no default. Used to initialize a fresh database."
 		},
 		{
 			"name": "application.elasticsearch.reindexer.getBatchSize",

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -63,7 +63,7 @@
 		{
 			"name": "application.jwt.encryption-secret",
 			"type": "java.lang.String",
-			"description": "JWT Secret. Required, no default. This must be a 256 bit HMAC hash in base64 encoding. Generate using `openssl rand -base64 32`"
+			"description": "JWT secret. Required, no default. This is the symmetric HMAC key used to both sign and verify tokens, and must be a 256 bit key in base64 encoding. Generate using `openssl rand -base64 32`"
 		},
 		{
 			"name": "application.jwt.accessTokenExpiration",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -137,8 +137,6 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
-    # The apikey-root-key placeholder is supplied by FlywayConfiguration, not here. See the
-    # comment there: binding it as a property silently swallows an unset ROOT_API_KEY.
     placeholder-replacement: true
     out-of-order: true
     ignore-missing-migrations: true
@@ -197,7 +195,7 @@ application:
   jwt:
     encryption-secret: ZWlubnN5bi10ZXN0LW9ubHktand0LXNlY3JldC1rZXk=
   apikey:
-    root-key: secret_test_only_not_a_real_credential
+    root-key: test_secret
   elasticsearch:
     uri: http://unreachable.example.com:9200
     searchType: dfs_query_then_fetch

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,12 +68,14 @@ application:
     verificationQuarantineHours: ${INNSYNSKRAV_BESTILLING_VERIFICATION_QUARANTINE_HOURS:1}
     verificationQuarantineLimit: ${INNSYNSKRAV_BESTILLING_VERIFICATION_QUARANTINE_LIMIT:1}
   jwt:
-    encryption-secret: ${JWT_SECRET:MzfS60YlMegsOaaz4SEqU54O7OjFPLsLqaNbYJockDg=}
+    # Required, no default. Generate with `openssl rand -base64 32`.
+    encryption-secret: ${JWT_SECRET}
     accessTokenExpiration: ${JWT_EXPIRATION:3600} # 1 hour
     refreshTokenExpiration: ${JWT_REFRESH_EXPIRATION:2419200} # 28 days
     issuerUri: ${JWT_ISSUER_URI:http://localhost:8080}
   apikey:
-    root-key: ${ROOT_API_KEY:secret_changeme}
+    # Required, no default. The secret of the root (administrator) API key.
+    root-key: ${ROOT_API_KEY}
   ansattporten:
     issuerUri: ${ANSATTPORTEN_ISSUER_URI:https://ansattporten.dev}
     allowSelfRegistration: ${ANSATTPORTEN_ALLOW_SELF_REGISTRATION:true}
@@ -135,8 +137,8 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
-    placeholders:
-      apikey-root-key: ${application.apikey.root-key}
+    # The apikey-root-key placeholder is supplied by FlywayConfiguration, not here. See the
+    # comment there: binding it as a property silently swallows an unset ROOT_API_KEY.
     placeholder-replacement: true
     out-of-order: true
     ignore-missing-migrations: true
@@ -189,6 +191,13 @@ spring:
     hikari:
       idle-timeout: 10000
 application:
+  # Placeholders, so tests don't depend on environment variables. Deliberately not secrets: they
+  # are only read under the "test" profile, which also points the datasource at a throwaway
+  # container. The JWT value is base64 of "einnsyn-test-only-jwt-secret-key".
+  jwt:
+    encryption-secret: ZWlubnN5bi10ZXN0LW9ubHktand0LXNlY3JldC1rZXk=
+  apikey:
+    root-key: secret_test_only_not_a_real_credential
   elasticsearch:
     uri: http://unreachable.example.com:9200
     searchType: dfs_query_then_fetch


### PR DESCRIPTION
The root admin API key defaulted to `secret_changeme` and the JWT HMAC signing secret to a value committed in this repository. Both are administrator-equivalent credentials: the root key authenticates as an administrator against every entity, and HS256 is symmetric, so knowing the JWT secret is the ability to mint a token for any Bruker. A missing environment variable failed open, silently.

Both properties are now required with no fallback. A SecretValidationEnvironmentPostProcessor additionally refuses to start when either is blank, or set to one of the two previously committed values, and checks that the JWT secret is base64 and at least 256 bits. It runs as an EnvironmentPostProcessor so the check happens before Flyway can seed the root API key into a fresh database.

The test profile supplies its own values so tests don't depend on the environment.