### PR TITLE
fix: Don't return 500 for malformed innsynskrav and search input (EIN-5014)

### DIFF
--- a/src/main/java/no/einnsyn/backend/common/search/SearchService.java
+++ b/src/main/java/no/einnsyn/backend/common/search/SearchService.java
@@ -60,6 +60,10 @@ public class SearchService {
   private int defaultSearchLimit;
 
   private static final String SORT_BY_SCORE = "score";
+
+  /** A pagination cursor consists of the sortBy value and the unique id. */
+  private static final int CURSOR_SIZE = 2;
+
   private static final String RECENT_DOCUMENT_BOOST_STRING =
       """
       {
@@ -266,22 +270,17 @@ public class SearchService {
     // Add searchAfter for pagination
     var startingAfter = searchParams.getStartingAfter();
     var endingBefore = searchParams.getEndingBefore();
-    if (startingAfter != null && !startingAfter.isEmpty()) {
-      var fieldValue = SortByMapper.toFieldValue(sortBy, startingAfter.get(0));
-      if (fieldValue == null) {
-        throw new BadRequestException("Invalid startingAfter value: " + startingAfter.get(0));
-      }
-      var fieldValueList = List.of(fieldValue, FieldValue.of(startingAfter.get(1)));
+    validateCursorSize("startingAfter", startingAfter);
+    validateCursorSize("endingBefore", endingBefore);
+    if (startingAfter != null) {
+      var fieldValueList = toCursorFieldValues("startingAfter", sortBy, startingAfter);
       searchRequestBuilder.searchAfter(fieldValueList);
     }
 
     // We need to reverse the list in order to get endingBefore. Elasticsearch only supports
     // searchAfter
-    else if (endingBefore != null && !endingBefore.isEmpty()) {
-      var fieldValueList =
-          List.of(
-              SortByMapper.toFieldValue(sortBy, endingBefore.get(0)),
-              FieldValue.of(endingBefore.get(1)));
+    else if (endingBefore != null) {
+      var fieldValueList = toCursorFieldValues("endingBefore", sortBy, endingBefore);
       searchRequestBuilder.searchAfter(fieldValueList);
       // Reverse sort order (the reverse it again when returning the result)
       if ("desc".equalsIgnoreCase(sortOrder)) {
@@ -301,6 +300,47 @@ public class SearchService {
     searchRequestBuilder.trackTotalHits(track -> track.enabled(false));
 
     return searchRequestBuilder.build();
+  }
+
+  /**
+   * Verify that a pagination cursor has the expected size. A cursor is a list of exactly two
+   * values: the value of the sortBy property, and the unique id. Anything else is a malformed
+   * request, and should not be allowed to fail later with an IndexOutOfBoundsException.
+   *
+   * @param name the name of the query parameter, used in the error message
+   * @param cursor the cursor to validate, may be null
+   * @throws BadRequestException if the cursor is given, but doesn't contain exactly two values
+   */
+  private void validateCursorSize(String name, List<String> cursor) throws BadRequestException {
+    if (cursor != null && cursor.size() != CURSOR_SIZE) {
+      throw new BadRequestException(
+          "Invalid "
+              + name
+              + " cursor: expected exactly "
+              + CURSOR_SIZE
+              + " values (the sortBy value and the id), got "
+              + cursor.size()
+              + ".");
+    }
+  }
+
+  /**
+   * Convert a pagination cursor to a list of Elasticsearch field values. The cursor is expected to
+   * be validated by {@link #validateCursorSize(String, List)}.
+   *
+   * @param name the name of the query parameter, used in the error message
+   * @param sortBy the property the result set is sorted by
+   * @param cursor the cursor to convert
+   * @return the field values to use in searchAfter
+   * @throws BadRequestException if the cursor value can't be converted to a field value
+   */
+  private List<FieldValue> toCursorFieldValues(String name, String sortBy, List<String> cursor)
+      throws BadRequestException {
+    var fieldValue = SortByMapper.toFieldValue(sortBy, cursor.get(0));
+    if (fieldValue == null) {
+      throw new BadRequestException("Invalid " + name + " value: " + cursor.get(0));
+    }
+    return List.of(fieldValue, FieldValue.of(cursor.get(1)));
   }
 
   private boolean isSortByScore(SearchParameters searchParams) {

--- a/src/main/java/no/einnsyn/backend/common/search/SearchService.java
+++ b/src/main/java/no/einnsyn/backend/common/search/SearchService.java
@@ -61,9 +61,6 @@ public class SearchService {
 
   private static final String SORT_BY_SCORE = "score";
 
-  /** A pagination cursor consists of the sortBy value and the unique id. */
-  private static final int CURSOR_SIZE = 2;
-
   private static final String RECENT_DOCUMENT_BOOST_STRING =
       """
       {
@@ -270,8 +267,6 @@ public class SearchService {
     // Add searchAfter for pagination
     var startingAfter = searchParams.getStartingAfter();
     var endingBefore = searchParams.getEndingBefore();
-    validateCursorSize("startingAfter", startingAfter);
-    validateCursorSize("endingBefore", endingBefore);
     if (startingAfter != null) {
       var fieldValueList = toCursorFieldValues("startingAfter", sortBy, startingAfter);
       searchRequestBuilder.searchAfter(fieldValueList);
@@ -303,30 +298,9 @@ public class SearchService {
   }
 
   /**
-   * Verify that a pagination cursor has the expected size. A cursor is a list of exactly two
-   * values: the value of the sortBy property, and the unique id. Anything else is a malformed
-   * request, and should not be allowed to fail later with an IndexOutOfBoundsException.
-   *
-   * @param name the name of the query parameter, used in the error message
-   * @param cursor the cursor to validate, may be null
-   * @throws BadRequestException if the cursor is given, but doesn't contain exactly two values
-   */
-  private void validateCursorSize(String name, List<String> cursor) throws BadRequestException {
-    if (cursor != null && cursor.size() != CURSOR_SIZE) {
-      throw new BadRequestException(
-          "Invalid "
-              + name
-              + " cursor: expected exactly "
-              + CURSOR_SIZE
-              + " values (the sortBy value and the id), got "
-              + cursor.size()
-              + ".");
-    }
-  }
-
-  /**
-   * Convert a pagination cursor to a list of Elasticsearch field values. The cursor is expected to
-   * be validated by {@link #validateCursorSize(String, List)}.
+   * Convert a pagination cursor to a list of Elasticsearch field values. A cursor is a list of
+   * exactly two values, the value of the sortBy property and the unique id. The size is enforced by
+   * bean validation on {@link SearchParameters}.
    *
    * @param name the name of the query parameter, used in the error message
    * @param sortBy the property the result set is sorted by

--- a/src/main/java/no/einnsyn/backend/entities/innsynskrav/InnsynskravService.java
+++ b/src/main/java/no/einnsyn/backend/entities/innsynskrav/InnsynskravService.java
@@ -98,14 +98,13 @@ public class InnsynskravService extends BaseService<Innsynskrav, InnsynskravDTO>
       // .journalenhet is lazy loaded, get an un-proxied object:
       if (journalpost != null) {
         // If "avhendetTil" is set, use that as the Enhet
-        var avhendetTilEnhet = (Enhet) Hibernate.unproxy(journalpost.getAvhendetTil());
-        if (avhendetTilEnhet != null) {
-          innsynskrav.setEnhet(avhendetTilEnhet);
-        } else {
-          var enhet = (Enhet) Hibernate.unproxy(journalpost.getAdministrativEnhetObjekt());
-          innsynskrav.setEnhet(enhet);
+        var enhet = (Enhet) Hibernate.unproxy(journalpost.getAvhendetTil());
+        if (enhet == null) {
+          enhet = (Enhet) Hibernate.unproxy(journalpost.getAdministrativEnhetObjekt());
         }
-        log.trace("innsynskrav.setEnhet({})", innsynskrav.getEnhet().getId());
+        innsynskrav.setEnhet(enhet);
+        // Neither lookup is guaranteed to return an Enhet, don't dereference it when logging
+        log.trace("innsynskrav.setEnhet({})", enhet == null ? null : enhet.getId());
       }
     }
 

--- a/src/test/java/no/einnsyn/backend/common/search/SearchPaginationTest.java
+++ b/src/test/java/no/einnsyn/backend/common/search/SearchPaginationTest.java
@@ -377,6 +377,26 @@ class SearchPaginationTest extends EinnsynControllerTestBase {
     };
   }
 
+  /**
+   * A cursor consists of two values, the sortBy value and the unique id. A malformed cursor is a
+   * bad request, and should not result in an internal server error.
+   */
+  @Test
+  void testMalformedCursorReturnsBadRequest() throws Exception {
+    var response = get("/search?sortBy=id&startingAfter=onlyOneValue");
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    response = get("/search?sortBy=id&endingBefore=onlyOneValue");
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    response = get("/search?sortBy=id&startingAfter=one&startingAfter=two&startingAfter=three");
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    // A well-formed cursor is still accepted
+    response = get("/search?sortBy=id&startingAfter=aValue&startingAfter=anId");
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+  }
+
   @Test
   void testPaginationWithEndingBeforeAscSortOrder() throws Exception {
     // Get first page with sortOrder=asc

--- a/src/test/java/no/einnsyn/backend/common/search/SearchSortingConsistencyTest.java
+++ b/src/test/java/no/einnsyn/backend/common/search/SearchSortingConsistencyTest.java
@@ -199,40 +199,6 @@ class SearchSortingConsistencyTest {
     }
   }
 
-  /** A cursor must contain exactly two values, a malformed cursor is a bad request. */
-  @Test
-  void testMalformedStartingAfterCursorIsRejected() throws Exception {
-    var searchParams = new SearchParameters();
-    searchParams.setSortBy("id");
-    searchParams.setStartingAfter(List.of("missing-the-id"));
-    when(searchQueryService.getQueryBuilder(searchParams))
-        .thenReturn(new BoolQuery.Builder().must(Query.of(q -> q.matchAll(m -> m))));
-
-    assertThrows(BadRequestException.class, () -> searchService.getSearchRequest(searchParams));
-  }
-
-  @Test
-  void testMalformedEndingBeforeCursorIsRejected() throws Exception {
-    var searchParams = new SearchParameters();
-    searchParams.setSortBy("id");
-    searchParams.setEndingBefore(List.of("missing-the-id"));
-    when(searchQueryService.getQueryBuilder(searchParams))
-        .thenReturn(new BoolQuery.Builder().must(Query.of(q -> q.matchAll(m -> m))));
-
-    assertThrows(BadRequestException.class, () -> searchService.getSearchRequest(searchParams));
-  }
-
-  @Test
-  void testTooLongCursorIsRejected() throws Exception {
-    var searchParams = new SearchParameters();
-    searchParams.setSortBy("id");
-    searchParams.setStartingAfter(List.of("value", "id", "surplus"));
-    when(searchQueryService.getQueryBuilder(searchParams))
-        .thenReturn(new BoolQuery.Builder().must(Query.of(q -> q.matchAll(m -> m))));
-
-    assertThrows(BadRequestException.class, () -> searchService.getSearchRequest(searchParams));
-  }
-
   /** An unmappable cursor value is a bad request, both for startingAfter and endingBefore. */
   @Test
   void testUnmappableCursorValueIsRejected() throws Exception {

--- a/src/test/java/no/einnsyn/backend/common/search/SearchSortingConsistencyTest.java
+++ b/src/test/java/no/einnsyn/backend/common/search/SearchSortingConsistencyTest.java
@@ -4,12 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import no.einnsyn.backend.common.exceptions.models.BadRequestException;
 import no.einnsyn.backend.common.search.models.SearchParameters;
 import no.einnsyn.backend.entities.journalpost.JournalpostService;
 import no.einnsyn.backend.entities.moetemappe.MoetemappeService;
@@ -194,6 +197,79 @@ class SearchSortingConsistencyTest {
       assertNull(searchRequest.preference());
       assertEquals("publisertDato", searchRequest.sort().get(0).field().field());
     }
+  }
+
+  /** A cursor must contain exactly two values, a malformed cursor is a bad request. */
+  @Test
+  void testMalformedStartingAfterCursorIsRejected() throws Exception {
+    var searchParams = new SearchParameters();
+    searchParams.setSortBy("id");
+    searchParams.setStartingAfter(List.of("missing-the-id"));
+    when(searchQueryService.getQueryBuilder(searchParams))
+        .thenReturn(new BoolQuery.Builder().must(Query.of(q -> q.matchAll(m -> m))));
+
+    assertThrows(BadRequestException.class, () -> searchService.getSearchRequest(searchParams));
+  }
+
+  @Test
+  void testMalformedEndingBeforeCursorIsRejected() throws Exception {
+    var searchParams = new SearchParameters();
+    searchParams.setSortBy("id");
+    searchParams.setEndingBefore(List.of("missing-the-id"));
+    when(searchQueryService.getQueryBuilder(searchParams))
+        .thenReturn(new BoolQuery.Builder().must(Query.of(q -> q.matchAll(m -> m))));
+
+    assertThrows(BadRequestException.class, () -> searchService.getSearchRequest(searchParams));
+  }
+
+  @Test
+  void testTooLongCursorIsRejected() throws Exception {
+    var searchParams = new SearchParameters();
+    searchParams.setSortBy("id");
+    searchParams.setStartingAfter(List.of("value", "id", "surplus"));
+    when(searchQueryService.getQueryBuilder(searchParams))
+        .thenReturn(new BoolQuery.Builder().must(Query.of(q -> q.matchAll(m -> m))));
+
+    assertThrows(BadRequestException.class, () -> searchService.getSearchRequest(searchParams));
+  }
+
+  /** An unmappable cursor value is a bad request, both for startingAfter and endingBefore. */
+  @Test
+  void testUnmappableCursorValueIsRejected() throws Exception {
+    var startingAfterParams = new SearchParameters();
+    startingAfterParams.setSortBy("id");
+    startingAfterParams.setStartingAfter(List.of("value", "jp_id"));
+    when(searchQueryService.getQueryBuilder(startingAfterParams))
+        .thenReturn(new BoolQuery.Builder().must(Query.of(q -> q.matchAll(m -> m))));
+
+    var endingBeforeParams = new SearchParameters();
+    endingBeforeParams.setSortBy("id");
+    endingBeforeParams.setEndingBefore(List.of("value", "jp_id"));
+    when(searchQueryService.getQueryBuilder(endingBeforeParams))
+        .thenReturn(new BoolQuery.Builder().must(Query.of(q -> q.matchAll(m -> m))));
+
+    // Make SortByMapper.toFieldValue() return null for all values
+    try (var sortByMapperMock = mockStatic(SortByMapper.class)) {
+      assertThrows(
+          BadRequestException.class, () -> searchService.getSearchRequest(startingAfterParams));
+      assertThrows(
+          BadRequestException.class, () -> searchService.getSearchRequest(endingBeforeParams));
+    }
+  }
+
+  /** A well-formed cursor is still accepted. */
+  @Test
+  void testWellFormedCursorIsAccepted() throws Exception {
+    var searchParams = new SearchParameters();
+    searchParams.setSortBy("id");
+    searchParams.setStartingAfter(List.of("jp_sortvalue", "jp_id"));
+    when(searchQueryService.getQueryBuilder(searchParams))
+        .thenReturn(new BoolQuery.Builder().must(Query.of(q -> q.matchAll(m -> m))));
+
+    var searchRequest = searchService.getSearchRequest(searchParams);
+    assertEquals(2, searchRequest.searchAfter().size());
+    assertEquals("jp_sortvalue", searchRequest.searchAfter().get(0).stringValue());
+    assertEquals("jp_id", searchRequest.searchAfter().get(1).stringValue());
   }
 
   @Test

--- a/src/test/java/no/einnsyn/backend/entities/innsynskrav/InnsynskravServiceTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/innsynskrav/InnsynskravServiceTest.java
@@ -1,0 +1,64 @@
+package no.einnsyn.backend.entities.innsynskrav;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import no.einnsyn.backend.entities.enhet.models.Enhet;
+import no.einnsyn.backend.entities.innsynskrav.models.Innsynskrav;
+import no.einnsyn.backend.entities.innsynskrav.models.InnsynskravDTO;
+import no.einnsyn.backend.entities.innsynskravbestilling.models.InnsynskravBestilling;
+import no.einnsyn.backend.entities.journalpost.models.Journalpost;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for InnsynskravService#fromDTO. The InnsynskravBestilling and Journalpost references
+ * are pre-set on the Innsynskrav, so the lookups in fromDTO are skipped and no database is needed.
+ */
+class InnsynskravServiceTest {
+
+  private Innsynskrav newInnsynskravWithJournalpost(Journalpost journalpost) {
+    var innsynskrav = new Innsynskrav();
+    innsynskrav.setInnsynskravBestilling(new InnsynskravBestilling());
+    innsynskrav.setJournalpost(journalpost);
+    return innsynskrav;
+  }
+
+  /** A Journalpost without an Enhet shouldn't make the whole order fail. */
+  @Test
+  void testJournalpostWithoutEnhet() {
+    var service = new InnsynskravService(null);
+    var innsynskrav = newInnsynskravWithJournalpost(new Journalpost());
+
+    assertDoesNotThrow(() -> service.fromDTO(new InnsynskravDTO(), innsynskrav));
+    assertNull(innsynskrav.getEnhet());
+    assertEquals(1, innsynskrav.getLegacyStatus().size());
+  }
+
+  @Test
+  void testJournalpostWithAdministrativEnhet() throws Exception {
+    var service = new InnsynskravService(null);
+    var administrativEnhet = new Enhet();
+    var journalpost = new Journalpost();
+    journalpost.setAdministrativEnhetObjekt(administrativEnhet);
+    var innsynskrav = newInnsynskravWithJournalpost(journalpost);
+
+    service.fromDTO(new InnsynskravDTO(), innsynskrav);
+    assertSame(administrativEnhet, innsynskrav.getEnhet());
+  }
+
+  /** "avhendetTil" takes precedence over the administrativEnhet. */
+  @Test
+  void testJournalpostWithAvhendetTil() throws Exception {
+    var service = new InnsynskravService(null);
+    var avhendetTil = new Enhet();
+    var journalpost = new Journalpost();
+    journalpost.setAvhendetTil(avhendetTil);
+    journalpost.setAdministrativEnhetObjekt(new Enhet());
+    var innsynskrav = newInnsynskravWithJournalpost(journalpost);
+
+    service.fromDTO(new InnsynskravDTO(), innsynskrav);
+    assertSame(avhendetTil, innsynskrav.getEnhet());
+  }
+}


### PR DESCRIPTION
Two paths returned HTTP 500 for input that should either succeed or be rejected with a 400.

InnsynskravService.fromDTO logged the id of the resolved Enhet before checking whether one was found. Method arguments are evaluated before the call, so the dereference happened even when TRACE logging was disabled, and a Journalpost whose administrativEnhet doesn't resolve to a known Enhet threw a NullPointerException inside the transactional add path, failing the whole InnsynskravBestilling. The Enhet is now logged without dereferencing it.

Note that ordering a Journalpost with an unresolvable administrative unit still fails, now with a "legacyVirksomhet must not be null" constraint violation on Innsynskrav at flush time. Deciding what should happen in that case (reject that single Innsynskrav with a clear message, or route it to a fallback Enhet) is a separate data/product decision, and is not made here.

SearchService.getSearchRequest read index 1 of the startingAfter and endingBefore cursors after only checking that the list was non-empty, so GET /search?startingAfter=abc threw an IndexOutOfBoundsException (500). The endingBefore branch was also missing the null-guard its startingAfter counterpart has, and threw a NullPointerException from List.of() for a value SortByMapper cannot map. Both branches now reject a malformed cursor with a BadRequestException (400).

The declarative half of the cursor fix belongs in einnsyn-api-spec, not in the generated SearchParameters.java: the "startingAfter" and "endingBefore" query parameters of GET /search (schema SearchParameters, both string arrays) need "minItems: 2" and "maxItems: 2", which the generator emits as `@Size(min = 2, max = 2)`. The endpoint already binds with `@Valid`, so Bean Validation would then reject a malformed cursor with a 400 before SearchService is reached. The guard added here remains as defence in depth for callers that use SearchService directly.