### PR TITLE
fix: validate nested objects as Insert, on PATCH to parent

### DIFF
--- a/src/main/java/no/einnsyn/backend/common/expandablefield/ExpandableField.java
+++ b/src/main/java/no/einnsyn/backend/common/expandablefield/ExpandableField.java
@@ -1,8 +1,11 @@
 package no.einnsyn.backend.common.expandablefield;
 
 import jakarta.validation.Valid;
+import jakarta.validation.groups.ConvertGroup;
 import no.einnsyn.backend.common.exceptions.models.BadRequestException;
 import no.einnsyn.backend.common.hasid.HasId;
+import no.einnsyn.backend.validation.validationgroups.Insert;
+import no.einnsyn.backend.validation.validationgroups.Update;
 
 /**
  * A class representing "expandable fields" in the API. These are fields that are either an ID or an
@@ -15,7 +18,13 @@ public class ExpandableField<T extends HasId> {
 
   private String id = null;
 
-  @Valid private T expandedObject = null;
+  // Expanded objects in a request body are always new objects: existing objects can only be
+  // referenced by ID (BaseDTO.id is @Null for both Insert and Update). Nested objects would
+  // otherwise be cascade-validated with the Update group during a parent update, skipping
+  // required-field (Insert) constraints.
+  @Valid
+  @ConvertGroup(from = Update.class, to = Insert.class)
+  private T expandedObject = null;
 
   public ExpandableField(String id) {
     this.id = id;

--- a/src/test/java/no/einnsyn/backend/entities/journalpost/JournalpostControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/journalpost/JournalpostControllerTest.java
@@ -1828,6 +1828,7 @@ class JournalpostControllerTest extends EinnsynControllerTestBase {
     // Clean up
     delete("/saksmappe/" + saksmappe.getId());
   }
+
   // Nested objects created through a parent PATCH are validated with the Insert group (converted
   // from Update in ExpandableField, since expanded objects are always new objects), so incomplete
   // nested objects must be rejected.
@@ -1865,5 +1866,4 @@ class JournalpostControllerTest extends EinnsynControllerTestBase {
 
     delete("/saksmappe/" + saksmappeDTO.getId());
   }
-
 }

--- a/src/test/java/no/einnsyn/backend/entities/journalpost/JournalpostControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/journalpost/JournalpostControllerTest.java
@@ -1863,7 +1863,7 @@ class JournalpostControllerTest extends EinnsynControllerTestBase {
     response = patch("/journalpost/" + journalpostDTO.getId(), patchJSON);
     assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
 
-    delete("/saksmappe/" + saksmappeDTO.getId());
+    assertEquals(HttpStatus.OK, delete("/saksmappe/" + saksmappeDTO.getId()).getStatusCode());
   }
 
 }

--- a/src/test/java/no/einnsyn/backend/entities/journalpost/JournalpostControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/journalpost/JournalpostControllerTest.java
@@ -1828,4 +1828,42 @@ class JournalpostControllerTest extends EinnsynControllerTestBase {
     // Clean up
     delete("/saksmappe/" + saksmappe.getId());
   }
+  // Nested objects created through a parent PATCH are validated with the Insert group (converted
+  // from Update in ExpandableField, since expanded objects are always new objects), so incomplete
+  // nested objects must be rejected.
+  @Test
+  void rejectIncompleteNestedObjectsOnPatch() throws Exception {
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", getSaksmappeJSON());
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var saksmappeDTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
+    response = post("/saksmappe/" + saksmappeDTO.getId() + "/journalpost", getJournalpostJSON());
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var journalpostDTO = gson.fromJson(response.getBody(), JournalpostDTO.class);
+
+    // Empty nested skjerming
+    var patchJSON = new JSONObject().put("skjerming", new JSONObject());
+    response = patch("/journalpost/" + journalpostDTO.getId(), patchJSON);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    // Empty nested korrespondansepart
+    patchJSON = new JSONObject().put("korrespondansepart", new JSONArray().put(new JSONObject()));
+    response = patch("/journalpost/" + journalpostDTO.getId(), patchJSON);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    // Empty nested dokumentbeskrivelse
+    patchJSON = new JSONObject().put("dokumentbeskrivelse", new JSONArray().put(new JSONObject()));
+    response = patch("/journalpost/" + journalpostDTO.getId(), patchJSON);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    // Valid dokumentbeskrivelse with an empty nested dokumentobjekt
+    var dokumentbeskrivelseJSON = getDokumentbeskrivelseJSON();
+    dokumentbeskrivelseJSON.put("dokumentobjekt", new JSONArray().put(new JSONObject()));
+    patchJSON =
+        new JSONObject().put("dokumentbeskrivelse", new JSONArray().put(dokumentbeskrivelseJSON));
+    response = patch("/journalpost/" + journalpostDTO.getId(), patchJSON);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    delete("/saksmappe/" + saksmappeDTO.getId());
+  }
+
 }

--- a/src/test/java/no/einnsyn/backend/entities/matrikkelnummer/MatrikkelnummerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/matrikkelnummer/MatrikkelnummerTest.java
@@ -322,8 +322,8 @@ class MatrikkelnummerTest extends EinnsynControllerTestBase {
     assertEquals(HttpStatus.OK, delete("/saksmappe/" + saksmappeDTO.getId()).getStatusCode());
   }
 
-  // Nested objects on PATCH are validated with the Update group, so the Insert-group
-  // constraints on required fields must be enforced by validateForCreate.
+  // Nested objects created through a parent PATCH are validated with the Insert group (converted
+  // from Update in ExpandableField), so incomplete nested objects must be rejected.
   @Test
   void rejectIncompleteNestedMatrikkelnummerOnPatch() throws Exception {
     var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", getSaksmappeJSON());

--- a/src/test/java/no/einnsyn/backend/entities/matrikkelnummer/MatrikkelnummerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/matrikkelnummer/MatrikkelnummerTest.java
@@ -322,6 +322,36 @@ class MatrikkelnummerTest extends EinnsynControllerTestBase {
     assertEquals(HttpStatus.OK, delete("/saksmappe/" + saksmappeDTO.getId()).getStatusCode());
   }
 
+  // Nested objects on PATCH are validated with the Update group, so the Insert-group
+  // constraints on required fields must be enforced by validateForCreate.
+  @Test
+  void rejectIncompleteNestedMatrikkelnummerOnPatch() throws Exception {
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", getSaksmappeJSON());
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var saksmappeDTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
+
+    response = post("/saksmappe/" + saksmappeDTO.getId() + "/journalpost", getJournalpostJSON());
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var journalpostDTO = gson.fromJson(response.getBody(), JournalpostDTO.class);
+
+    var incompleteJSON = new JSONObject();
+    incompleteJSON.put("gaardsnummer", 30);
+    incompleteJSON.put("bruksnummer", 60);
+    // no kommunenummer
+
+    // Mappe hierarchy (Saksmappe)
+    var patchJSON = new JSONObject();
+    patchJSON.put("matrikkelnummer", new JSONArray().put(incompleteJSON));
+    response = patch("/saksmappe/" + saksmappeDTO.getId(), patchJSON);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    // Registrering hierarchy (Journalpost)
+    response = patch("/journalpost/" + journalpostDTO.getId(), patchJSON);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    assertEquals(HttpStatus.OK, delete("/saksmappe/" + saksmappeDTO.getId()).getStatusCode());
+  }
+
   @Test
   void addAndListMatrikkelnummerViaSaksmappe() throws Exception {
     var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", getSaksmappeJSON());

--- a/src/test/java/no/einnsyn/backend/entities/moetemappe/MoetemappeControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/moetemappe/MoetemappeControllerTest.java
@@ -673,6 +673,7 @@ class MoetemappeControllerTest extends EinnsynControllerTestBase {
     assertEquals(HttpStatus.OK, delete("/moetemappe/" + moetemappe3DTO.getId()).getStatusCode());
     assertEquals(HttpStatus.OK, delete("/arkiv/" + arkiv2DTO.getId()).getStatusCode());
   }
+
   // Nested objects created through a parent PATCH are validated with the Insert group (converted
   // from Update in ExpandableField, since expanded objects are always new objects), so incomplete
   // nested objects must be rejected.
@@ -694,5 +695,4 @@ class MoetemappeControllerTest extends EinnsynControllerTestBase {
 
     assertEquals(HttpStatus.OK, delete("/moetemappe/" + moetemappeDTO.getId()).getStatusCode());
   }
-
 }

--- a/src/test/java/no/einnsyn/backend/entities/moetemappe/MoetemappeControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/moetemappe/MoetemappeControllerTest.java
@@ -673,4 +673,26 @@ class MoetemappeControllerTest extends EinnsynControllerTestBase {
     assertEquals(HttpStatus.OK, delete("/moetemappe/" + moetemappe3DTO.getId()).getStatusCode());
     assertEquals(HttpStatus.OK, delete("/arkiv/" + arkiv2DTO.getId()).getStatusCode());
   }
+  // Nested objects created through a parent PATCH are validated with the Insert group (converted
+  // from Update in ExpandableField, since expanded objects are always new objects), so incomplete
+  // nested objects must be rejected.
+  @Test
+  void rejectIncompleteNestedObjectsOnPatch() throws Exception {
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/moetemappe", getMoetemappeJSON());
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var moetemappeDTO = gson.fromJson(response.getBody(), MoetemappeDTO.class);
+
+    // Empty nested moetesak
+    var patchJSON = new JSONObject().put("moetesak", new JSONArray().put(new JSONObject()));
+    response = patch("/moetemappe/" + moetemappeDTO.getId(), patchJSON);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    // Empty nested moetedokument
+    patchJSON = new JSONObject().put("moetedokument", new JSONArray().put(new JSONObject()));
+    response = patch("/moetemappe/" + moetemappeDTO.getId(), patchJSON);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    assertEquals(HttpStatus.OK, delete("/moetemappe/" + moetemappeDTO.getId()).getStatusCode());
+  }
+
 }

--- a/src/test/java/no/einnsyn/backend/entities/moetesak/MoetesakControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/moetesak/MoetesakControllerTest.java
@@ -867,6 +867,7 @@ class MoetesakControllerTest extends EinnsynControllerTestBase {
         List.of(MoetesakDTO.MoetesakstypeEnum.ANNET, "unknown_type"),
         List.of(MoetesakDTO.MoetesakstypeEnum.ANNET, "ukjent"));
   }
+
   // Nested objects created through a parent PATCH are validated with the Insert group (converted
   // from Update in ExpandableField, since expanded objects are always new objects), so incomplete
   // nested objects must be rejected
@@ -899,5 +900,4 @@ class MoetesakControllerTest extends EinnsynControllerTestBase {
     var refreshedDTO = gson.fromJson(response.getBody(), MoetesakDTO.class);
     assertEquals(utredningId, refreshedDTO.getUtredning().getId());
   }
-
 }

--- a/src/test/java/no/einnsyn/backend/entities/moetesak/MoetesakControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/moetesak/MoetesakControllerTest.java
@@ -867,4 +867,37 @@ class MoetesakControllerTest extends EinnsynControllerTestBase {
         List.of(MoetesakDTO.MoetesakstypeEnum.ANNET, "unknown_type"),
         List.of(MoetesakDTO.MoetesakstypeEnum.ANNET, "ukjent"));
   }
+  // Nested objects created through a parent PATCH are validated with the Insert group (converted
+  // from Update in ExpandableField, since expanded objects are always new objects), so incomplete
+  // nested objects must be rejected
+  // instead of replacing existing sub-objects with empty ones.
+  @Test
+  void rejectIncompleteNestedObjectsOnPatch() throws Exception {
+    var response = post("/moetemappe/" + moetemappeDTO.getId() + "/moetesak", getMoetesakJSON());
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var moetesakDTO = gson.fromJson(response.getBody(), MoetesakDTO.class);
+    var utredningId = moetesakDTO.getUtredning().getId();
+
+    // Empty nested utredning
+    var patchJSON = new JSONObject().put("utredning", new JSONObject());
+    response = patch("/moetesak/" + moetesakDTO.getId(), patchJSON);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    // Empty nested vedtak
+    patchJSON = new JSONObject().put("vedtak", new JSONObject());
+    response = patch("/moetesak/" + moetesakDTO.getId(), patchJSON);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    // Empty nested innstilling
+    patchJSON = new JSONObject().put("innstilling", new JSONObject());
+    response = patch("/moetesak/" + moetesakDTO.getId(), patchJSON);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    // The existing utredning must not have been replaced by the rejected PATCHes
+    response = get("/moetesak/" + moetesakDTO.getId());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    var refreshedDTO = gson.fromJson(response.getBody(), MoetesakDTO.class);
+    assertEquals(utredningId, refreshedDTO.getUtredning().getId());
+  }
+
 }

--- a/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
@@ -822,4 +822,21 @@ class SaksmappeControllerTest extends EinnsynControllerTestBase {
     response = delete("/saksmappe/" + saksmappe2DTO.getId());
     assertEquals(HttpStatus.OK, response.getStatusCode());
   }
+  // Nested objects created through a parent PATCH are validated with the Insert group (converted
+  // from Update in ExpandableField, since expanded objects are always new objects), so incomplete
+  // nested objects must be rejected.
+  @Test
+  void rejectIncompleteNestedJournalpostOnPatch() throws Exception {
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", getSaksmappeJSON());
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var saksmappeDTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
+
+    // Empty nested journalpost
+    var patchJSON = new JSONObject().put("journalpost", new JSONArray().put(new JSONObject()));
+    response = patch("/saksmappe/" + saksmappeDTO.getId(), patchJSON);
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    assertEquals(HttpStatus.OK, delete("/saksmappe/" + saksmappeDTO.getId()).getStatusCode());
+  }
+
 }

--- a/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
@@ -822,6 +822,7 @@ class SaksmappeControllerTest extends EinnsynControllerTestBase {
     response = delete("/saksmappe/" + saksmappe2DTO.getId());
     assertEquals(HttpStatus.OK, response.getStatusCode());
   }
+
   // Nested objects created through a parent PATCH are validated with the Insert group (converted
   // from Update in ExpandableField, since expanded objects are always new objects), so incomplete
   // nested objects must be rejected.
@@ -838,5 +839,4 @@ class SaksmappeControllerTest extends EinnsynControllerTestBase {
 
     assertEquals(HttpStatus.OK, delete("/saksmappe/" + saksmappeDTO.getId()).getStatusCode());
   }
-
 }


### PR DESCRIPTION
When PATCHing an object, the request is validated as an "Update". So, when adding child objects to a PATCH request, the children are validated as updates even though you cannot update a child element by PATCHing a parent. Child elements will always be inserts, so they should be validated as "Insert".