### PR TITLE
EIN-5020: Resolve alternative identifiers in path variables

### DIFF
--- a/src/main/java/no/einnsyn/backend/configuration/ConverterConfiguration.java
+++ b/src/main/java/no/einnsyn/backend/configuration/ConverterConfiguration.java
@@ -1,18 +1,28 @@
 package no.einnsyn.backend.configuration;
 
+import com.google.gson.Gson;
 import java.util.Collections;
 import java.util.List;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/** Converters used when binding request parameters and path variables. */
 @Configuration
-public class StringListConverterConfig implements WebMvcConfigurer {
+public class ConverterConfiguration implements WebMvcConfigurer {
+
+  private final ObjectProvider<Gson> gsonProvider;
+
+  public ConverterConfiguration(ObjectProvider<Gson> gsonProvider) {
+    this.gsonProvider = gsonProvider;
+  }
 
   @Override
   public void addFormatters(FormatterRegistry registry) {
     registry.addConverter(new StringToListConverter());
+    registry.addConverter(new StringToExpandableFieldConverter(gsonProvider.getObject()));
   }
 
   static class StringToListConverter implements Converter<String, List<String>> {

--- a/src/main/java/no/einnsyn/backend/configuration/StringToExpandableFieldConverter.java
+++ b/src/main/java/no/einnsyn/backend/configuration/StringToExpandableFieldConverter.java
@@ -1,0 +1,58 @@
+package no.einnsyn.backend.configuration;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonPrimitive;
+import jakarta.annotation.Nullable;
+import java.util.Set;
+import no.einnsyn.backend.common.expandablefield.ExpandableField;
+import no.einnsyn.backend.configuration.typeadapters.ExpandableFieldDeserializer;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalGenericConverter;
+
+/**
+ * Converts a String to an {@link ExpandableField}, by handing it to the same Gson deserializer that
+ * parses expandable fields in request bodies.
+ *
+ * <p>Path variables are bound by Spring's ConversionService, not by the HTTP message converters, so
+ * they never reach Gson on their own. Without this converter Spring falls back to its generic
+ * {@code ObjectToObjectConverter}, which picks up {@link ExpandableField#ExpandableField(String)}
+ * and stores the raw path segment verbatim. Alternative identifiers (systemId, slug, orgnummer,
+ * email, ...) would then be resolved in request bodies but not in path variables, leaving every
+ * consumer of a path variable to re-resolve it.
+ *
+ * @see ExpandableFieldDeserializer the deserializer this delegates to
+ */
+public class StringToExpandableFieldConverter implements ConditionalGenericConverter {
+
+  private final Gson gson;
+
+  public StringToExpandableFieldConverter(Gson gson) {
+    this.gson = gson;
+  }
+
+  @Override
+  public Set<ConvertiblePair> getConvertibleTypes() {
+    return Set.of(new ConvertiblePair(String.class, ExpandableField.class));
+  }
+
+  @Override
+  public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
+    // ExpandableFieldDeserializer reads the entity class from the generic type parameter, so a raw
+    // ExpandableField is left to the default conversion.
+    return targetType.getResolvableType().hasGenerics();
+  }
+
+  @Override
+  @Nullable
+  public Object convert(
+      @Nullable Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
+    if (source == null) {
+      return null;
+    }
+
+    // Wrapping the value as a JSON string hits the same branch of ExpandableFieldDeserializer that
+    // an ID reference in a request body does.
+    return gson.fromJson(
+        new JsonPrimitive((String) source), targetType.getResolvableType().getType());
+  }
+}

--- a/src/main/java/no/einnsyn/backend/utils/id/IdResolver.java
+++ b/src/main/java/no/einnsyn/backend/utils/id/IdResolver.java
@@ -38,16 +38,30 @@ import no.einnsyn.backend.entities.lagretsoek.LagretSoekService;
 import no.einnsyn.backend.entities.lagretsoek.models.LagretSoekDTO;
 import no.einnsyn.backend.entities.mappe.MappeService;
 import no.einnsyn.backend.entities.mappe.models.MappeDTO;
+import no.einnsyn.backend.entities.matrikkelnummer.MatrikkelnummerService;
+import no.einnsyn.backend.entities.matrikkelnummer.models.MatrikkelnummerDTO;
 import no.einnsyn.backend.entities.moetedeltaker.MoetedeltakerService;
 import no.einnsyn.backend.entities.moetedeltaker.models.MoetedeltakerDTO;
 import no.einnsyn.backend.entities.moetedokument.MoetedokumentService;
 import no.einnsyn.backend.entities.moetedokument.models.MoetedokumentDTO;
 import no.einnsyn.backend.entities.moetemappe.MoetemappeService;
 import no.einnsyn.backend.entities.moetemappe.models.MoetemappeDTO;
+import no.einnsyn.backend.entities.moetesak.MoetesakService;
+import no.einnsyn.backend.entities.moetesak.models.MoetesakDTO;
+import no.einnsyn.backend.entities.moetesaksbeskrivelse.MoetesaksbeskrivelseService;
+import no.einnsyn.backend.entities.moetesaksbeskrivelse.models.MoetesaksbeskrivelseDTO;
 import no.einnsyn.backend.entities.registrering.RegistreringService;
 import no.einnsyn.backend.entities.registrering.models.RegistreringDTO;
 import no.einnsyn.backend.entities.saksmappe.SaksmappeService;
 import no.einnsyn.backend.entities.saksmappe.models.SaksmappeDTO;
+import no.einnsyn.backend.entities.skjerming.SkjermingService;
+import no.einnsyn.backend.entities.skjerming.models.SkjermingDTO;
+import no.einnsyn.backend.entities.utredning.UtredningService;
+import no.einnsyn.backend.entities.utredning.models.UtredningDTO;
+import no.einnsyn.backend.entities.vedtak.VedtakService;
+import no.einnsyn.backend.entities.vedtak.models.VedtakDTO;
+import no.einnsyn.backend.entities.votering.VoteringService;
+import no.einnsyn.backend.entities.votering.models.VoteringDTO;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
@@ -86,11 +100,18 @@ public class IdResolver {
           Map.entry(LagretSakDTO.class, LagretSakService.class),
           Map.entry(LagretSoekDTO.class, LagretSoekService.class),
           Map.entry(MappeDTO.class, MappeService.class),
+          Map.entry(MatrikkelnummerDTO.class, MatrikkelnummerService.class),
           Map.entry(MoetedeltakerDTO.class, MoetedeltakerService.class),
           Map.entry(MoetedokumentDTO.class, MoetedokumentService.class),
           Map.entry(MoetemappeDTO.class, MoetemappeService.class),
+          Map.entry(MoetesakDTO.class, MoetesakService.class),
+          Map.entry(MoetesaksbeskrivelseDTO.class, MoetesaksbeskrivelseService.class),
           Map.entry(RegistreringDTO.class, RegistreringService.class),
-          Map.entry(SaksmappeDTO.class, SaksmappeService.class));
+          Map.entry(SaksmappeDTO.class, SaksmappeService.class),
+          Map.entry(SkjermingDTO.class, SkjermingService.class),
+          Map.entry(UtredningDTO.class, UtredningService.class),
+          Map.entry(VedtakDTO.class, VedtakService.class),
+          Map.entry(VoteringDTO.class, VoteringService.class));
 
   public IdResolver(ApplicationContext applicationContext) {
     this.applicationContext = applicationContext;

--- a/src/test/java/no/einnsyn/backend/entities/matrikkelnummer/MatrikkelnummerESTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/matrikkelnummer/MatrikkelnummerESTest.java
@@ -150,7 +150,9 @@ class MatrikkelnummerESTest extends EinnsynLegacyElasticTestBase {
     assertNotNull(
         documentMap.get(moetesakDTO.getId()),
         "Moetesak should be reindexed under its canonical ID");
-
+    assertNotNull(
+        documentMap.get(moetemappeDTO.getId()),
+        "Moetemappe should be reindexed under its canonical ID");
     delete("/moetemappe/" + moetemappeDTO.getId());
   }
 

--- a/src/test/java/no/einnsyn/backend/entities/matrikkelnummer/MatrikkelnummerESTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/matrikkelnummer/MatrikkelnummerESTest.java
@@ -9,6 +9,8 @@ import no.einnsyn.backend.EinnsynLegacyElasticTestBase;
 import no.einnsyn.backend.entities.arkiv.models.ArkivDTO;
 import no.einnsyn.backend.entities.arkivdel.models.ArkivdelDTO;
 import no.einnsyn.backend.entities.matrikkelnummer.models.MatrikkelnummerDTO;
+import no.einnsyn.backend.entities.moetemappe.models.MoetemappeDTO;
+import no.einnsyn.backend.entities.moetesak.models.MoetesakDTO;
 import no.einnsyn.backend.entities.saksmappe.models.SaksmappeDTO;
 import no.einnsyn.backend.entities.saksmappe.models.SaksmappeES;
 import org.json.JSONArray;
@@ -82,6 +84,74 @@ class MatrikkelnummerESTest extends EinnsynLegacyElasticTestBase {
         "Saksmappe should be reindexed after matrikkelnummer deletion");
 
     delete("/saksmappe/" + saksmappeDTO.getId());
+  }
+
+  /**
+   * Test that a systemId used as path parameter is resolved to the canonical eInnsyn ID before the
+   * parent is scheduled for indexing. ElasticsearchHandlerInterceptor dispatches queued entries by
+   * ID prefix, so an unresolved systemId is silently dropped and the parent is never reindexed.
+   */
+  @Test
+  void reindexParentWhenMatrikkelnummerAddedBySystemId() throws Exception {
+    var systemId = "0f2b6c19-7e4a-4d51-9a3c-8b5e1d6f2a70";
+    var saksmappeJSON = getSaksmappeJSON();
+    saksmappeJSON.put("systemId", systemId);
+
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", saksmappeJSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var saksmappeDTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
+
+    // Saksmappe creation triggers one index call
+    captureIndexedDocuments(1);
+    resetEs();
+
+    // Add a matrikkelnummer, using the Saksmappe's systemId as path parameter
+    response =
+        post("/saksmappe/" + systemId + "/matrikkelnummer", getMatrikkelnummerJSON("0301", 11, 98));
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+
+    // The parent must be reindexed, under its canonical ID
+    var documentMap = captureIndexedDocuments(1);
+    assertNotNull(
+        documentMap.get(saksmappeDTO.getId()),
+        "Saksmappe should be reindexed under its canonical ID");
+
+    delete("/saksmappe/" + saksmappeDTO.getId());
+  }
+
+  /**
+   * Same as above for Moetesak, whose DTO class was missing from IdResolver's entity/service map.
+   * Resolution is silent when an entry is missing, so this covers the map rather than the
+   * converter.
+   */
+  @Test
+  void reindexParentWhenMoetesakMatrikkelnummerAddedBySystemId() throws Exception {
+    var systemId = "3c8e1a45-6b27-4f93-a1d0-7e5c2b9f4a68";
+    var moetemappeJSON = getMoetemappeJSON();
+    moetemappeJSON.remove("moetesak");
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/moetemappe", moetemappeJSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var moetemappeDTO = gson.fromJson(response.getBody(), MoetemappeDTO.class);
+
+    var moetesakJSON = getMoetesakJSON();
+    moetesakJSON.put("systemId", systemId);
+    response = post("/moetemappe/" + moetemappeDTO.getId() + "/moetesak", moetesakJSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var moetesakDTO = gson.fromJson(response.getBody(), MoetesakDTO.class);
+    resetEs();
+
+    // Add a matrikkelnummer, using the Moetesak's systemId as path parameter
+    response =
+        post("/moetesak/" + systemId + "/matrikkelnummer", getMatrikkelnummerJSON("0301", 12, 97));
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+
+    // Moetesak and its parent Moetemappe are both reindexed, under their canonical IDs
+    var documentMap = captureIndexedDocuments(2);
+    assertNotNull(
+        documentMap.get(moetesakDTO.getId()),
+        "Moetesak should be reindexed under its canonical ID");
+
+    delete("/moetemappe/" + moetemappeDTO.getId());
   }
 
   @Test

--- a/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
@@ -19,6 +19,7 @@ import no.einnsyn.backend.common.responses.models.PaginatedList;
 import no.einnsyn.backend.entities.arkiv.models.ArkivDTO;
 import no.einnsyn.backend.entities.arkivdel.models.ArkivdelDTO;
 import no.einnsyn.backend.entities.journalpost.models.JournalpostDTO;
+import no.einnsyn.backend.entities.matrikkelnummer.models.MatrikkelnummerDTO;
 import no.einnsyn.backend.entities.saksmappe.models.SaksmappeDTO;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -705,6 +706,57 @@ class SaksmappeControllerTest extends EinnsynControllerTestBase {
     assertEquals(
         HttpStatus.NOT_FOUND,
         get("/saksmappe/4b1a6279-d4a9-49f1-8c95-a0e8810bf1b5").getStatusCode());
+  }
+
+  /**
+   * Test that a systemId can be used as path parameter when adding sub-resources.
+   *
+   * @see no.einnsyn.backend.entities.matrikkelnummer.MatrikkelnummerESTest for the accompanying
+   *     check that the parent is reindexed under its canonical ID
+   */
+  @Test
+  void addSubResourcesBySystemId() throws Exception {
+    var systemId = "9d1c5f83-3b58-4a2e-8c0f-2f6d1b7a4e11";
+    var saksmappeJSON = getSaksmappeJSON();
+    saksmappeJSON.put("systemId", systemId);
+
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", saksmappeJSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var saksmappeDTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
+
+    // Add a Journalpost, using the Saksmappe's systemId as path parameter
+    response = post("/saksmappe/" + systemId + "/journalpost", getJournalpostJSON());
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var journalpostDTO = gson.fromJson(response.getBody(), JournalpostDTO.class);
+    assertEquals(saksmappeDTO.getId(), journalpostDTO.getSaksmappe().getId());
+
+    // Add a Matrikkelnummer, using the Saksmappe's systemId as path parameter
+    response =
+        post("/saksmappe/" + systemId + "/matrikkelnummer", getMatrikkelnummerJSON("0301", 7, 21));
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+
+    // Both sub-resources are listable through the canonical ID
+    response = get("/saksmappe/" + saksmappeDTO.getId() + "/journalpost");
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    var journalpostList =
+        gson.fromJson(
+            response.getBody(), new TypeToken<PaginatedList<JournalpostDTO>>() {}.getType());
+    assertEquals(1, ((PaginatedList<JournalpostDTO>) journalpostList).getItems().size());
+
+    response = get("/saksmappe/" + saksmappeDTO.getId() + "/matrikkelnummer");
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    var matrikkelnummerList =
+        gson.fromJson(
+            response.getBody(), new TypeToken<PaginatedList<MatrikkelnummerDTO>>() {}.getType());
+    assertEquals(1, ((PaginatedList<MatrikkelnummerDTO>) matrikkelnummerList).getItems().size());
+
+    // An unresolvable systemId is passed through unchanged, so validation still reports it missing
+    assertEquals(
+        HttpStatus.NOT_FOUND,
+        post("/saksmappe/00000000-0000-0000-0000-000000000000/journalpost", getJournalpostJSON())
+            .getStatusCode());
+
+    delete("/saksmappe/" + saksmappeDTO.getId());
   }
 
   /**

--- a/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
@@ -738,10 +738,10 @@ class SaksmappeControllerTest extends EinnsynControllerTestBase {
     // Both sub-resources are listable through the canonical ID
     response = get("/saksmappe/" + saksmappeDTO.getId() + "/journalpost");
     assertEquals(HttpStatus.OK, response.getStatusCode());
-    var journalpostList =
+    PaginatedList<JournalpostDTO> journalpostList =
         gson.fromJson(
             response.getBody(), new TypeToken<PaginatedList<JournalpostDTO>>() {}.getType());
-    assertEquals(1, ((PaginatedList<JournalpostDTO>) journalpostList).getItems().size());
+    assertEquals(1, journalpostList.getItems().size());
 
     response = get("/saksmappe/" + saksmappeDTO.getId() + "/matrikkelnummer");
     assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
@@ -745,10 +745,10 @@ class SaksmappeControllerTest extends EinnsynControllerTestBase {
 
     response = get("/saksmappe/" + saksmappeDTO.getId() + "/matrikkelnummer");
     assertEquals(HttpStatus.OK, response.getStatusCode());
-    var matrikkelnummerList =
+    PaginatedList<MatrikkelnummerDTO> matrikkelnummerList =
         gson.fromJson(
             response.getBody(), new TypeToken<PaginatedList<MatrikkelnummerDTO>>() {}.getType());
-    assertEquals(1, ((PaginatedList<MatrikkelnummerDTO>) matrikkelnummerList).getItems().size());
+    assertEquals(1, matrikkelnummerList.getItems().size());
 
     // An unresolvable systemId is passed through unchanged, so validation still reports it missing
     assertEquals(


### PR DESCRIPTION
Path variables are bound by Spring's ConversionService, not by the HTTP message converters, so an ExpandableField path variable never reached Gson. Spring fell back to ObjectToObjectConverter, which picks up ExpandableField(String) and stored the raw path segment verbatim. Alternative identifiers (systemId, slug, orgnummer, email, ...) were therefore resolved in request bodies but not in path variables, leaving every consumer of a path variable to re-resolve it.

Add StringToExpandableFieldConverter, which hands the value to the same Gson deserializer that parses expandable fields in request bodies, and register it alongside the existing list converter. StringListConverterConfig is renamed to ConverterConfiguration, since it now holds more than one converter.

Also add the DTO classes that were missing from IdResolver's entity/service map. Resolution is silent when an entry is missing, so a Matrikkelnummer added under a Moetesak systemId left the parent unindexed: ElasticsearchHandlerInterceptor dispatches queued entries by ID prefix, and an unresolved systemId is dropped.