### PR TITLE
EIN-5021: Accept alternative identifiers in the "ids" list parameter

### DIFF
--- a/src/main/java/no/einnsyn/backend/entities/base/BaseService.java
+++ b/src/main/java/no/einnsyn/backend/entities/base/BaseService.java
@@ -225,6 +225,29 @@ public abstract class BaseService<O extends Base, D extends BaseDTO> {
   }
 
   /**
+   * Resolve a list of unique identifiers (systemId, slug, orgnummer, email, externalId, ...) to
+   * entity IDs, preserving the order of the input list.
+   *
+   * <p>Identifiers that already are IDs of this entity type are passed through without a lookup, so
+   * a list of plain IDs costs no queries. Identifiers that cannot be resolved are also passed
+   * through unchanged, and will simply not match anything. Resolution never fails: callers such as
+   * {@link #listEntity(ListParameters, int)} are expected to silently skip identifiers with no
+   * match, the same way they skip IDs of objects the caller cannot access.
+   *
+   * @param identifiers the unique identifiers to resolve
+   * @return the resolved entity IDs, in the order of the input list
+   */
+  @Transactional(readOnly = true)
+  public List<String> resolveIds(List<String> identifiers) {
+    var resolvedIds = new ArrayList<String>(identifiers.size());
+    for (var identifier : identifiers) {
+      var resolvedId = getProxy().resolveId(identifier);
+      resolvedIds.add(resolvedId != null ? resolvedId : identifier);
+    }
+    return resolvedIds;
+  }
+
+  /**
    * Finds an entity by its unique identifier. If the ID does not start with the current entity's ID
    * prefix, it is treated as an external ID or a system ID. Subclasses may extend this method to
    * provide additional lookup logic, for instance lookup by email address.
@@ -1263,6 +1286,9 @@ public abstract class BaseService<O extends Base, D extends BaseDTO> {
    * <p>The method fetches enough rows for {@link #list(ListParameters)} to determine whether there
    * are more pages available.
    *
+   * <p>The {@code ids} parameter accepts any unique identifier accepted by {@link #find(String)},
+   * not only entity IDs, see {@link #resolveIds(List)}.
+   *
    * @param params The query parameters for pagination
    * @param limit The maximum number of entities to fetch
    * @return a list of matching entities
@@ -1281,8 +1307,10 @@ public abstract class BaseService<O extends Base, D extends BaseDTO> {
 
     var ids = params.getIds();
     if (ids != null) {
-      var entityList = getRepository().findByIdIn(ids);
-      Collections.sort(entityList, Comparator.comparingInt(entity -> ids.indexOf(entity.getId())));
+      var resolvedIds = getProxy().resolveIds(ids);
+      var entityList = getRepository().findByIdIn(resolvedIds);
+      Collections.sort(
+          entityList, Comparator.comparingInt(entity -> resolvedIds.indexOf(entity.getId())));
       return entityList;
     }
 

--- a/src/test/java/no/einnsyn/backend/entities/enhet/EnhetControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/enhet/EnhetControllerTest.java
@@ -998,6 +998,45 @@ class EnhetControllerTest extends EinnsynControllerTestBase {
     assertEquals(HttpStatus.OK, delete("/enhet/" + enhet4DTO.getId()).getStatusCode());
   }
 
+  // Test /enhet?ids=... with orgnummer and slug instead of eInnsyn IDs
+  @Test
+  void testListEnhetByAlternativeIds() throws Exception {
+    var resultListType = new TypeToken<PaginatedList<EnhetDTO>>() {}.getType();
+
+    var enhet1JSON = getEnhetJSON();
+    enhet1JSON.put("navn", "AlternativeIds" + System.nanoTime());
+    var response = post("/enhet/" + journalenhetId + "/underenhet", enhet1JSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var enhet1DTO = gson.fromJson(response.getBody(), EnhetDTO.class);
+    assertNotNull(enhet1DTO.getSlug());
+
+    var enhet2JSON = getEnhetJSON();
+    response = post("/enhet/" + journalenhetId + "/underenhet", enhet2JSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var enhet2DTO = gson.fromJson(response.getBody(), EnhetDTO.class);
+
+    // Orgnummer and slug both resolve to the canonical ID
+    for (var identifier : List.of(enhet1DTO.getOrgnummer(), enhet1DTO.getSlug())) {
+      response = get("/enhet?ids=" + identifier);
+      assertEquals(HttpStatus.OK, response.getStatusCode());
+      PaginatedList<EnhetDTO> list = gson.fromJson(response.getBody(), resultListType);
+      assertEquals(1, list.getItems().size(), "Should resolve " + identifier);
+      assertEquals(enhet1DTO.getId(), list.getItems().getFirst().getId());
+    }
+
+    // Mixed with an eInnsyn ID, keeping the order of the query parameters
+    response = get("/enhet?ids=" + enhet2DTO.getId() + "&ids=" + enhet1DTO.getOrgnummer());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    PaginatedList<EnhetDTO> list = gson.fromJson(response.getBody(), resultListType);
+    assertEquals(2, list.getItems().size());
+    assertEquals(enhet2DTO.getId(), list.getItems().get(0).getId());
+    assertEquals(enhet1DTO.getId(), list.getItems().get(1).getId());
+
+    // Cleanup
+    assertEquals(HttpStatus.OK, delete("/enhet/" + enhet1DTO.getId()).getStatusCode());
+    assertEquals(HttpStatus.OK, delete("/enhet/" + enhet2DTO.getId()).getStatusCode());
+  }
+
   // Test sort order, limit, and pagination cursors with /enhet?query=...
   @Test
   @SuppressWarnings("java:S5961") // Allow many asserts

--- a/src/test/java/no/einnsyn/backend/entities/journalpost/JournalpostControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/journalpost/JournalpostControllerTest.java
@@ -1341,6 +1341,44 @@ class JournalpostControllerTest extends EinnsynControllerTestBase {
     assertEquals(HttpStatus.NOT_FOUND, getDeletedSaksmappeResponse.getStatusCode());
   }
 
+  /**
+   * Test that resolving an alternative identifier in the "ids" list parameter is subject to the
+   * same accessibleAfter filtering as a lookup by eInnsyn ID. Resolution runs through the
+   * repository inside the request transaction, so the Hibernate filters enabled by
+   * AccessibleFilterAspect apply, and an inaccessible Journalpost cannot be reached through its
+   * systemId.
+   */
+  @Test
+  void listByAlternativeIdsRespectsAccessibleAfter() throws Exception {
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", getSaksmappeJSON());
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var saksmappeDTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
+
+    var systemId = "8a3f5c71-2e94-4b60-9d18-6c7a3e5b1f42";
+    var journalpostJSON = getJournalpostAccessibleInFutureJSON();
+    journalpostJSON.put("systemId", systemId);
+    response = post("/saksmappe/" + saksmappeDTO.getId() + "/journalpost", journalpostJSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var journalpostDTO = gson.fromJson(response.getBody(), JournalpostDTO.class);
+
+    var resultListType = new TypeToken<PaginatedList<JournalpostDTO>>() {}.getType();
+
+    // Anonymous users can't reach the inaccessible Journalpost through its systemId
+    response = getAnon("/journalpost?ids=" + systemId);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    PaginatedList<JournalpostDTO> resultList = gson.fromJson(response.getBody(), resultListType);
+    assertEquals(0, resultList.getItems().size());
+
+    // Admins can
+    response = getAdmin("/journalpost?ids=" + systemId);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    resultList = gson.fromJson(response.getBody(), resultListType);
+    assertEquals(1, resultList.getItems().size());
+    assertEquals(journalpostDTO.getId(), resultList.getItems().getFirst().getId());
+
+    delete("/saksmappe/" + saksmappeDTO.getId());
+  }
+
   @Test
   void testAddWithAdministrativEnhet() throws Exception {
     var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", getSaksmappeJSON());

--- a/src/test/java/no/einnsyn/backend/entities/journalpost/JournalpostControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/journalpost/JournalpostControllerTest.java
@@ -1376,7 +1376,7 @@ class JournalpostControllerTest extends EinnsynControllerTestBase {
     assertEquals(1, resultList.getItems().size());
     assertEquals(journalpostDTO.getId(), resultList.getItems().getFirst().getId());
 
-    delete("/saksmappe/" + saksmappeDTO.getId());
+    assertEquals(HttpStatus.OK, delete("/saksmappe/" + saksmappeDTO.getId()).getStatusCode());
   }
 
   @Test

--- a/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
@@ -522,6 +522,64 @@ class SaksmappeControllerTest extends EinnsynControllerTestBase {
     assertEquals(HttpStatus.NOT_FOUND, get("/saksmappe/" + sm5.getId()).getStatusCode());
   }
 
+  /**
+   * Test that the "ids" list parameter accepts the same alternative identifiers as the get
+   * endpoint, mixed freely with eInnsyn IDs, and that the result keeps the order of the query
+   * parameters.
+   */
+  @Test
+  void listByAlternativeIds() throws Exception {
+    var systemId = "5f7b2d64-9c18-4e30-b7a2-1d4c6e8f3b95";
+    var saksmappeJSON = getSaksmappeJSON();
+    saksmappeJSON.put("systemId", systemId);
+    saksmappeJSON.put("externalId", "listByAlternativeIds-externalId");
+    var response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", saksmappeJSON);
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var saksmappe1DTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
+    assertNotNull(saksmappe1DTO.getSlug());
+
+    response = post("/arkivdel/" + arkivdelDTO.getId() + "/saksmappe", getSaksmappeJSON());
+    assertEquals(HttpStatus.CREATED, response.getStatusCode());
+    var saksmappe2DTO = gson.fromJson(response.getBody(), SaksmappeDTO.class);
+
+    var resultListType = new TypeToken<PaginatedList<SaksmappeDTO>>() {}.getType();
+
+    // A systemId, a slug and an externalId all resolve to the canonical ID
+    for (var identifier :
+        new String[] {systemId, saksmappe1DTO.getSlug(), "listByAlternativeIds-externalId"}) {
+      response = get("/saksmappe?ids=" + identifier);
+      assertEquals(HttpStatus.OK, response.getStatusCode());
+      PaginatedList<SaksmappeDTO> resultList = gson.fromJson(response.getBody(), resultListType);
+      assertEquals(1, resultList.getItems().size(), "Should resolve " + identifier);
+      assertEquals(saksmappe1DTO.getId(), resultList.getItems().getFirst().getId());
+    }
+
+    // Alternative identifiers can be mixed with eInnsyn IDs, and the input order is kept
+    response = get("/saksmappe?ids=" + saksmappe2DTO.getId() + "&ids=" + systemId);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    PaginatedList<SaksmappeDTO> resultList = gson.fromJson(response.getBody(), resultListType);
+    assertEquals(2, resultList.getItems().size());
+    assertEquals(saksmappe2DTO.getId(), resultList.getItems().get(0).getId());
+    assertEquals(saksmappe1DTO.getId(), resultList.getItems().get(1).getId());
+
+    // Identifiers with no match are skipped, they don't fail the request
+    response =
+        get("/saksmappe?ids=00000000-0000-0000-0000-000000000000&ids=" + saksmappe1DTO.getSlug());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    resultList = gson.fromJson(response.getBody(), resultListType);
+    assertEquals(1, resultList.getItems().size());
+    assertEquals(saksmappe1DTO.getId(), resultList.getItems().getFirst().getId());
+
+    // An ID belonging to another entity type is not resolved
+    response = get("/saksmappe?ids=" + arkivdelDTO.getId());
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    resultList = gson.fromJson(response.getBody(), resultListType);
+    assertEquals(0, resultList.getItems().size());
+
+    delete("/saksmappe/" + saksmappe1DTO.getId());
+    delete("/saksmappe/" + saksmappe2DTO.getId());
+  }
+
   // Test recursive deletion from Arkiv
   @Test
   void testDeletionFromArkiv() throws Exception {

--- a/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/saksmappe/SaksmappeControllerTest.java
@@ -576,8 +576,8 @@ class SaksmappeControllerTest extends EinnsynControllerTestBase {
     resultList = gson.fromJson(response.getBody(), resultListType);
     assertEquals(0, resultList.getItems().size());
 
-    delete("/saksmappe/" + saksmappe1DTO.getId());
-    delete("/saksmappe/" + saksmappe2DTO.getId());
+    assertEquals(HttpStatus.OK, delete("/saksmappe/" + saksmappe1DTO.getId()).getStatusCode());
+    assertEquals(HttpStatus.OK, delete("/saksmappe/" + saksmappe2DTO.getId()).getStatusCode());
   }
 
   // Test recursive deletion from Arkiv


### PR DESCRIPTION
Entity list endpoints only matched eInnsyn IDs in "ids", while the corresponding get endpoint accepts any unique identifier the entity service knows: systemId, slug, orgnummer, email, externalId, IRI. A client holding systemIds had to resolve each one through a separate get request before it could batch them.

Resolve in listEntity rather than at binding time. "ids" lives on the shared ListParameters, so a Spring converter has no entity type to resolve against, unlike an ExpandableField path variable which carries one as a generic parameter.

resolveIds() delegates to the existing per-identifier resolveId(), which short-circuits identifiers that already carry this entity's prefix, so a list of plain IDs still costs a single query. Resolution goes through the repository inside the request transaction, so the Hibernate filters enabled by AccessibleFilterAspect apply and an inaccessible object cannot be reached through its systemId. Identifiers with no match are passed through unchanged and simply don't match, keeping the existing behaviour where unknown IDs are skipped instead of failing the request.

Note that "ids" still bypasses parent scoping for sub-resource lists, as it did before this change.