### PR TITLE
EIN-5022: bind Ansattporten tokens to clientId, resource and action

### DIFF
--- a/src/main/java/no/einnsyn/backend/authentication/ansattporten/AnsattportenAuthenticationProvider.java
+++ b/src/main/java/no/einnsyn/backend/authentication/ansattporten/AnsattportenAuthenticationProvider.java
@@ -21,69 +21,72 @@ import org.springframework.stereotype.Component;
 @Component
 public class AnsattportenAuthenticationProvider implements AuthenticationProvider {
 
+  private static final String ALTINN_RESOURCE = "ansattporten:altinn:resource";
+
   private final AuthenticationService authenticationService;
   private final EnhetService enhetService;
   private final JwtDecoder jwtDecoder;
   private final String ansattportenIssuerUri;
+  private final String clientId;
+  private final String resource;
 
   public AnsattportenAuthenticationProvider(
       AuthenticationService authenticationService,
       EnhetService enhetService,
       @Qualifier("ansattportenJwtDecoder") JwtDecoder jwtDecoder,
-      @Value("${application.ansattporten.issuerUri}") String ansattportenIssuerUri) {
+      @Value("${application.ansattporten.issuerUri}") String ansattportenIssuerUri,
+      @Value("${application.ansattporten.clientId}") String clientId,
+      @Value("${application.ansattporten.resource}") String resource) {
     this.authenticationService = authenticationService;
     this.enhetService = enhetService;
     this.jwtDecoder = jwtDecoder;
     this.ansattportenIssuerUri = ansattportenIssuerUri;
+    this.clientId = clientId;
+    this.resource = resource;
   }
 
   @Override
   public Authentication authenticate(Authentication authentication) throws AuthenticationException {
-    var token = (String) authentication.getCredentials();
-
     Jwt jwt;
     try {
-      jwt = jwtDecoder.decode(token);
+      jwt = jwtDecoder.decode((String) authentication.getCredentials());
     } catch (Exception e) {
-      // If decoding fails, we assume it's not a valid Ansattporten token.
       return null;
     }
 
-    var issuer = jwt.getIssuer().toString();
-    if (!issuer.equals(ansattportenIssuerUri)) {
-      // Not an Ansattporten token.
+    if (jwt.getIssuer() == null
+        || !ansattportenIssuerUri.equals(jwt.getIssuer().toString())
+        || !jwt.getAudience().contains(clientId)) {
       return null;
     }
 
-    // Find orgnummers from the token
+    var orgnummers = getWritableOrgnummers(jwt);
+    if (orgnummers.isEmpty()) {
+      return null;
+    }
+
     String representingId = null;
-    String representingOrgnummer = null;
-    var orgnummers = getOrgnummersFromJWT(jwt);
+    String representingOrgnummer = orgnummers.getFirst();
     var enhetList = new ArrayList<Enhet>();
     for (var orgnummer : orgnummers) {
-      if (representingOrgnummer == null) {
-        representingOrgnummer = orgnummer;
-      }
       var enhet = enhetService.find(orgnummer);
       if (enhet != null) {
+        enhetList.add(enhet);
         if (representingId == null) {
           representingId = enhet.getId();
           representingOrgnummer = orgnummer;
         }
-        enhetList.add(enhet);
       }
     }
 
-    // Create a principal with the orgnummers and set it in the security context
+    var authorities = authenticationService.getAuthoritiesFromEnhet(enhetList, "Write");
+
     var principal =
         new EInnsynPrincipalEnhet(
             "Ansattporten", jwt.getSubject(), representingId, representingOrgnummer, false);
-
-    var authorities = authenticationService.getAuthoritiesFromEnhet(enhetList, "Write");
-    var authResult = new EInnsynAuthentication(principal, null, authorities);
-    authResult.setAuthenticated(true);
-
-    return authResult;
+    var result = new EInnsynAuthentication(principal, null, authorities);
+    result.setAuthenticated(true);
+    return result;
   }
 
   @Override
@@ -91,91 +94,43 @@ public class AnsattportenAuthenticationProvider implements AuthenticationProvide
     return EInnsynAuthentication.class.isAssignableFrom(authentication);
   }
 
-  /**
-   * Extracts organization numbers from the JWT's "authorization_details" claim.
-   *
-   * @param jwt The decoded Ansattporten JWT token.
-   * @return A list of orgnummer values.
-   */
-  private List<String> getOrgnummersFromJWT(Jwt jwt) {
-    var authDetailsClaim = jwt.getClaim("authorization_details");
-    if (authDetailsClaim instanceof List<?> authDetailsList) {
-      var organizationNumbers = new LinkedHashSet<String>();
+  private List<String> getWritableOrgnummers(Jwt jwt) {
+    var orgnummers = new LinkedHashSet<String>();
+    var claim = jwt.getClaim("authorization_details");
+    if (!(claim instanceof List<?> details)) {
+      return List.of();
+    }
 
-      for (var authDetail : authDetailsList) {
-        if (authDetail instanceof Map<?, ?> authDetailMap) {
-          var typeClaim = authDetailMap.get("type");
+    for (var value : details) {
+      if (!(value instanceof Map<?, ?> detail)
+          || !ALTINN_RESOURCE.equals(detail.get("type"))
+          || !resource.equals(detail.get("resource"))
+          || !(detail.get("authorized_parties") instanceof List<?> parties)) {
+        continue;
+      }
 
-          // Altinn 3 resource
-          if ("ansattporten:altinn:resource".equals(typeClaim)) {
-            var authorizedPartiesClaim = authDetailMap.get("authorized_parties");
-            if (authorizedPartiesClaim instanceof List authorizedPartiesClaimList) {
-              for (var authorizedPartyClaim : authorizedPartiesClaimList) {
-                if (authorizedPartyClaim instanceof Map<?, ?> authorizedPartyMap) {
-                  var orgNoClaim = authorizedPartyMap.get("orgno");
-                  var orgNo = getOrgNoFromClaim(orgNoClaim);
-                  if (orgNo != null) {
-                    organizationNumbers.add(orgNo);
-                  }
-                }
-              }
-            }
-          }
-
-          // Altinn 2 service
-          else if ("ansattporten:altinn:service".equals(typeClaim)) {
-            var reporteesClaim = authDetailMap.get("reportees");
-            if (reporteesClaim instanceof List reporteesClaimList) {
-              for (var reportee : reporteesClaimList) {
-                if (reportee instanceof Map<?, ?> reporteeMap) {
-                  var authority = reporteeMap.get("Authority");
-                  var idClaim = reporteeMap.get("ID");
-
-                  if ("iso6523-actorid-upis".equals(authority)
-                      && idClaim instanceof String idString) {
-                    var orgNo = getOrgNoFromISO6523(idString);
-                    if (orgNo != null) {
-                      organizationNumbers.add(orgNo);
-                    }
-                  }
-                }
-              }
-            }
-          }
-
-          // Entra ID
-          else if ("ansattporten:orgno".equals(typeClaim)) {
-            var orgNoClaim = authDetailMap.get("orgno");
-            var orgNo = getOrgNoFromClaim(orgNoClaim);
-            if (orgNo != null) {
-              organizationNumbers.add(orgNo);
-            }
-          }
+      for (var partyValue : parties) {
+        if (!(partyValue instanceof Map<?, ?> party)
+            || !(party.get("actions") instanceof List<?> actions)
+            || !actions.contains("write")) {
+          continue;
+        }
+        var orgnummer = getOrgNoFromClaim(party.get("orgno"));
+        if (orgnummer != null) {
+          orgnummers.add(orgnummer);
         }
       }
-
-      return List.copyOf(organizationNumbers);
     }
 
-    return List.of();
+    return List.copyOf(orgnummers);
   }
 
-  private String getOrgNoFromClaim(Object orgnoClaim) {
-    if (orgnoClaim instanceof Map<?, ?> orgnoMap) {
-      var authority = orgnoMap.get("authority");
-      var id = orgnoMap.get("ID");
-
-      if ("iso6523-actorid-upis".equals(authority) && id instanceof String idString) {
-        return getOrgNoFromISO6523(idString);
-      }
-    }
-    return null;
-  }
-
-  private String getOrgNoFromISO6523(String id) {
-    // Norwegian orgnummers are prefixed with "0192:"
-    if (id != null && id.startsWith("0192:")) {
-      return id.substring(5); // Skip "0192:"
+  private String getOrgNoFromClaim(Object claim) {
+    if (claim instanceof Map<?, ?> orgno
+        && "iso6523-actorid-upis".equals(orgno.get("authority"))
+        && orgno.get("ID") instanceof String id
+        && id.startsWith("0192:")) {
+      return id.substring(5);
     }
     return null;
   }

--- a/src/main/java/no/einnsyn/backend/authentication/ansattporten/AnsattportenAuthenticationProvider.java
+++ b/src/main/java/no/einnsyn/backend/authentication/ansattporten/AnsattportenAuthenticationProvider.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import no.einnsyn.backend.authentication.AuthenticationService;
 import no.einnsyn.backend.authentication.EInnsynAuthentication;
 import no.einnsyn.backend.authentication.EInnsynPrincipalEnhet;
@@ -18,6 +19,7 @@ import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class AnsattportenAuthenticationProvider implements AuthenticationProvider {
 
@@ -51,17 +53,26 @@ public class AnsattportenAuthenticationProvider implements AuthenticationProvide
     try {
       jwt = jwtDecoder.decode((String) authentication.getCredentials());
     } catch (Exception e) {
+      log.debug("Not an Ansattporten token, could not decode: {}", e.getMessage());
       return null;
     }
 
-    if (jwt.getIssuer() == null
-        || !ansattportenIssuerUri.equals(jwt.getIssuer().toString())
-        || !jwt.getAudience().contains(clientId)) {
+    if (jwt.getIssuer() == null || !ansattportenIssuerUri.equals(jwt.getIssuer().toString())) {
+      log.debug(
+          "Rejecting token, expected issuer {}, got {}", ansattportenIssuerUri, jwt.getIssuer());
       return null;
     }
 
-    var orgnummers = getWritableOrgnummers(jwt);
+    // Ansattporten access tokens carry the requesting client in "client_id", not in "aud".
+    var tokenClientId = jwt.getClaimAsString("client_id");
+    if (!clientId.equals(tokenClientId)) {
+      log.debug("Rejecting token, client_id {} does not match {}", tokenClientId, clientId);
+      return null;
+    }
+
+    var orgnummers = getAuthorizedOrgnummers(jwt);
     if (orgnummers.isEmpty()) {
+      log.debug("Rejecting token, no orgnummer is authorized for {}", resource);
       return null;
     }
 
@@ -94,31 +105,51 @@ public class AnsattportenAuthenticationProvider implements AuthenticationProvide
     return EInnsynAuthentication.class.isAssignableFrom(authentication);
   }
 
-  private List<String> getWritableOrgnummers(Jwt jwt) {
+  /**
+   * Collects the organization numbers the token is authorized for. Altinn 3 expresses access by
+   * listing a party under the requested resource, the parties carry no per-action claims.
+   */
+  private List<String> getAuthorizedOrgnummers(Jwt jwt) {
     var orgnummers = new LinkedHashSet<String>();
     var claim = jwt.getClaim("authorization_details");
     if (!(claim instanceof List<?> details)) {
+      log.debug("authorization_details is missing or not a list: {}", claim);
       return List.of();
     }
 
     for (var value : details) {
-      if (!(value instanceof Map<?, ?> detail)
-          || !ALTINN_RESOURCE.equals(detail.get("type"))
-          || !resource.equals(detail.get("resource"))
-          || !(detail.get("authorized_parties") instanceof List<?> parties)) {
+      if (!(value instanceof Map<?, ?> detail)) {
+        log.debug("Skipping authorization_details entry, not an object: {}", value);
+        continue;
+      }
+      if (!ALTINN_RESOURCE.equals(detail.get("type")) || !resource.equals(detail.get("resource"))) {
+        log.debug(
+            "Skipping authorization_details entry, expected type {} and resource {}, got {}",
+            ALTINN_RESOURCE,
+            resource,
+            detail);
+        continue;
+      }
+      if (!(detail.get("authorized_parties") instanceof List<?> parties)) {
+        log.debug(
+            "Skipping authorization_details entry, authorized_parties is missing or not a list:"
+                + " {}",
+            detail.get("authorized_parties"));
         continue;
       }
 
       for (var partyValue : parties) {
-        if (!(partyValue instanceof Map<?, ?> party)
-            || !(party.get("actions") instanceof List<?> actions)
-            || !actions.contains("write")) {
+        if (!(partyValue instanceof Map<?, ?> party)) {
+          log.debug("Skipping authorized party, not an object: {}", partyValue);
           continue;
         }
         var orgnummer = getOrgNoFromClaim(party.get("orgno"));
-        if (orgnummer != null) {
-          orgnummers.add(orgnummer);
+        if (orgnummer == null) {
+          log.debug(
+              "Skipping authorized party, could not read orgnummer from {}", party.get("orgno"));
+          continue;
         }
+        orgnummers.add(orgnummer);
       }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,10 +79,10 @@ application:
   ansattporten:
     issuerUri: ${ANSATTPORTEN_ISSUER_URI:https://ansattporten.dev}
     allowSelfRegistration: ${ANSATTPORTEN_ALLOW_SELF_REGISTRATION:true}
-    # Required, no defaults. These bind tokens to our client and Altinn 3 resources. Tokens without
-    # the "write" action are rejected.
-    clientId: ${ANSATTPORTEN_CLIENT_ID}
-    resource: ${ANSATTPORTEN_RESOURCE}
+    # Required. If unset/empty, all Ansattporten tokens will be rejected.
+    # These bind tokens to our client and Altinn 3 resources.
+    clientId: ${ANSATTPORTEN_CLIENT_ID:}
+    resource: ${ANSATTPORTEN_RESOURCE:}
 
 spring:
   application:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,6 +79,10 @@ application:
   ansattporten:
     issuerUri: ${ANSATTPORTEN_ISSUER_URI:https://ansattporten.dev}
     allowSelfRegistration: ${ANSATTPORTEN_ALLOW_SELF_REGISTRATION:true}
+    # Required, no defaults. These bind tokens to our client and Altinn 3 resources. Tokens without
+    # the "write" action are rejected.
+    clientId: ${ANSATTPORTEN_CLIENT_ID}
+    resource: ${ANSATTPORTEN_RESOURCE}
 
 spring:
   application:
@@ -205,6 +209,9 @@ application:
   innsynskrav:
     anonymousMaxAge: 1
     verificationQuarantineLimit: 10
+  ansattporten:
+    clientId: einnsyn-test-client
+    resource: urn:altinn:resource:einnsyn-api
 management:
   defaults:
     metrics:

--- a/src/test/java/no/einnsyn/backend/auth/ansattporten/AnsattportenAuthenticationTest.java
+++ b/src/test/java/no/einnsyn/backend/auth/ansattporten/AnsattportenAuthenticationTest.java
@@ -198,28 +198,16 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
   }
 
   @Test
-  void shouldRejectTokensWithoutWriteAccessToEInnsyn() throws Exception {
+  void shouldRejectTokensForOtherClientsOrResources() throws Exception {
     assertRejected(
         generateMockAltinn3Jwt(
-            journalenhetOrgnummer,
-            ansattportenIssuerUri,
-            "another-client",
-            TEST_RESOURCE,
-            List.of("write")));
-    assertRejected(
-        generateMockAltinn3Jwt(
-            journalenhetOrgnummer,
-            ansattportenIssuerUri,
-            TEST_CLIENT_ID,
-            "urn:altinn:resource:unrelated",
-            List.of("write")));
+            journalenhetOrgnummer, ansattportenIssuerUri, "another-client", TEST_RESOURCE));
     assertRejected(
         generateMockAltinn3Jwt(
             journalenhetOrgnummer,
             ansattportenIssuerUri,
             TEST_CLIENT_ID,
-            TEST_RESOURCE,
-            List.of("read")));
+            "urn:altinn:resource:unrelated"));
   }
 
   private void assertRejected(String jwt) throws Exception {
@@ -244,13 +232,11 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
   }
 
   static String generateMockAltinn3Jwt(String orgnummer, String issuerUri) throws Exception {
-    return generateMockAltinn3Jwt(
-        orgnummer, issuerUri, TEST_CLIENT_ID, TEST_RESOURCE, List.of("write"));
+    return generateMockAltinn3Jwt(orgnummer, issuerUri, TEST_CLIENT_ID, TEST_RESOURCE);
   }
 
   private static String generateMockAltinn3Jwt(
-      String orgnummer, String issuerUri, String clientId, String resource, List<String> actions)
-      throws Exception {
+      String orgnummer, String issuerUri, String clientId, String resource) throws Exception {
     var now = Instant.now();
     var expiryTimeSeconds = 3600L;
 
@@ -259,22 +245,22 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
             // Ansattporten returns a random subject
             .subject(IdGenerator.generateId("subject"))
             .issuer(issuerUri)
-            .audience(clientId)
+            // Ansattporten sets no "aud" on access tokens, the client is in "client_id"
+            .claim("client_id", clientId)
             .jwtID(UUID.randomUUID().toString())
             .issueTime(Date.from(now))
             .expirationTime(Date.from(now.plusSeconds(expiryTimeSeconds)));
 
-    // Add authorization_details
+    // Add authorization_details, shaped like a real Ansattporten Altinn 3 access token. The
+    // authorized parties carry no "actions", access is expressed by being listed for the resource.
     claimsSetBuilder.claim(
         "authorization_details",
         List.of(
             Map.of(
-                "resource",
-                resource,
                 "type",
                 "ansattporten:altinn:resource",
-                "resource_name",
-                "eInnsyn API resource",
+                "resource",
+                resource,
                 "authorized_parties",
                 List.of(
                     Map.of(
@@ -282,8 +268,8 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
                         Map.of("authority", "iso6523-actorid-upis", "ID", "0192:" + orgnummer),
                         "resource",
                         "einnsyn-api",
-                        "actions",
-                        actions,
+                        "name",
+                        "ANSTENDIG UNØYAKTIG TIGER AS",
                         "unit_type",
                         "AS")))));
 

--- a/src/test/java/no/einnsyn/backend/auth/ansattporten/AnsattportenAuthenticationTest.java
+++ b/src/test/java/no/einnsyn/backend/auth/ansattporten/AnsattportenAuthenticationTest.java
@@ -42,10 +42,12 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
 
   public static final KeyPair TEST_KEY_PAIR = generateTestRsaKeyPair();
   public static final String TEST_KEY_ID = "test-ansattporten-rsa-key-1";
+  private static final String TEST_CLIENT_ID = "einnsyn-test-client";
+  private static final String TEST_RESOURCE = "urn:altinn:resource:einnsyn-api";
 
   @Test
   void testAuthInfo() throws Exception {
-    var jwt = generateMockAltinn2Jwt(journalenhetOrgnummer);
+    var jwt = generateMockAltinn3Jwt(journalenhetOrgnummer);
     var response = get("/me", jwt);
     var authInfo = gson.fromJson(response.getBody(), AuthInfo.class);
     assertEquals("Ansattporten", authInfo.getAuthType());
@@ -53,7 +55,7 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
     assertEquals(journalenhetId, authInfo.getId());
     assertEquals(journalenhetOrgnummer, authInfo.getOrgnummer());
 
-    jwt = generateMockAltinn2Jwt(journalenhet2Orgnummer);
+    jwt = generateMockAltinn3Jwt(journalenhet2Orgnummer);
     response = get("/me", jwt);
     authInfo = gson.fromJson(response.getBody(), AuthInfo.class);
     assertEquals("Ansattporten", authInfo.getAuthType());
@@ -61,7 +63,7 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
     assertEquals(journalenhet2Id, authInfo.getId());
     assertEquals(journalenhet2Orgnummer, authInfo.getOrgnummer());
 
-    jwt = generateMockAltinn2Jwt("123456789");
+    jwt = generateMockAltinn3Jwt("123456789");
     response = get("/me", jwt);
     authInfo = gson.fromJson(response.getBody(), AuthInfo.class);
     assertEquals("Ansattporten", authInfo.getAuthType());
@@ -96,79 +98,30 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
     response = patch("/saksmappe/" + saksmappeDTO.getId(), getSaksmappeJSON(), journalenhetKey);
     assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
 
-    // Should be able to update as Journalenhet2 using Ansattporten Altinn2 JWT
-    var journalenhet2Altinn2Jwt = generateMockAltinn2Jwt(journalenhet2Orgnummer);
-    response = patch("/arkiv/" + arkivDTO.getId(), getArkivJSON(), journalenhet2Altinn2Jwt);
+    // Should be able to update as Journalenhet2 using Ansattporten Altinn 3 JWT
+    var journalenhet2Jwt = generateMockAltinn3Jwt(journalenhet2Orgnummer);
+    response = patch("/arkiv/" + arkivDTO.getId(), getArkivJSON(), journalenhet2Jwt);
     assertEquals(HttpStatus.OK, response.getStatusCode());
     arkivDTO = gson.fromJson(response.getBody(), ArkivDTO.class);
     assertEquals(journalenhet2Id, arkivDTO.getJournalenhet().getId());
-    response =
-        patch("/arkivdel/" + arkivdelDTO.getId(), getArkivdelJSON(), journalenhet2Altinn2Jwt);
+    response = patch("/arkivdel/" + arkivdelDTO.getId(), getArkivdelJSON(), journalenhet2Jwt);
     assertEquals(HttpStatus.OK, response.getStatusCode());
-
-    // Should be able to update as Journalenhet2 using Ansattporten Altinn3 JWT
-    var journalenhet2Altinn3Jwt = generateMockAltinn3Jwt(journalenhet2Orgnummer);
-    response = patch("/arkiv/" + arkivDTO.getId(), getArkivJSON(), journalenhet2Altinn3Jwt);
-    assertEquals(HttpStatus.OK, response.getStatusCode());
-    arkivDTO = gson.fromJson(response.getBody(), ArkivDTO.class);
-    assertEquals(journalenhet2Id, arkivDTO.getJournalenhet().getId());
-    response =
-        patch("/arkivdel/" + arkivdelDTO.getId(), getArkivdelJSON(), journalenhet2Altinn3Jwt);
-    assertEquals(HttpStatus.OK, response.getStatusCode());
-
-    // Should be able to update as Journalenhet2 using Ansattporten Entra ID JWT
-    var journalenhet2EntraIdJwt = generateMockEntraIdJwt(journalenhet2Orgnummer);
-    response = patch("/arkiv/" + arkivDTO.getId(), getArkivJSON(), journalenhet2EntraIdJwt);
-    assertEquals(HttpStatus.OK, response.getStatusCode());
-    arkivDTO = gson.fromJson(response.getBody(), ArkivDTO.class);
-    assertEquals(journalenhet2Id, arkivDTO.getJournalenhet().getId());
-    response =
-        patch("/arkivdel/" + arkivdelDTO.getId(), getArkivdelJSON(), journalenhet2EntraIdJwt);
-    assertEquals(HttpStatus.OK, response.getStatusCode());
-
-    // Should not be able to update as Journalenhet1 using Ansattporten Altinn 2 JWT
-    var journalenhet1Altinn2Jwt = generateMockAltinn2Jwt(journalenhetOrgnummer);
-    response = patch("/arkiv/" + arkivDTO.getId(), getArkivJSON(), journalenhet1Altinn2Jwt);
-    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
-    response =
-        patch("/arkivdel/" + arkivdelDTO.getId(), getArkivdelJSON(), journalenhet1Altinn2Jwt);
-    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
-    response =
-        patch("/saksmappe/" + saksmappeDTO.getId(), getSaksmappeJSON(), journalenhet1Altinn2Jwt);
-    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
 
     // Should not be able to update as Journalenhet1 using Ansattporten Altinn 3 JWT
-    var journalenhet1Altinn3Jwt = generateMockAltinn3Jwt(journalenhetOrgnummer);
-    response = patch("/arkiv/" + arkivDTO.getId(), getArkivJSON(), journalenhet1Altinn3Jwt);
+    var journalenhet1Jwt = generateMockAltinn3Jwt(journalenhetOrgnummer);
+    response = patch("/arkiv/" + arkivDTO.getId(), getArkivJSON(), journalenhet1Jwt);
     assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
-    response =
-        patch("/arkivdel/" + arkivdelDTO.getId(), getArkivdelJSON(), journalenhet1Altinn3Jwt);
+    response = patch("/arkivdel/" + arkivdelDTO.getId(), getArkivdelJSON(), journalenhet1Jwt);
     assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
-    response =
-        patch("/saksmappe/" + saksmappeDTO.getId(), getSaksmappeJSON(), journalenhet1Altinn3Jwt);
+    response = patch("/saksmappe/" + saksmappeDTO.getId(), getSaksmappeJSON(), journalenhet1Jwt);
     assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
 
-    // Should not be able to update as Journalenhet1 using Ansattporten Entra ID JWT
-    var journalenhet1EntraIdJwt = generateMockEntraIdJwt(journalenhetOrgnummer);
-    response = patch("/arkiv/" + arkivDTO.getId(), getArkivJSON(), journalenhet1EntraIdJwt);
-    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
-    response =
-        patch("/arkivdel/" + arkivdelDTO.getId(), getArkivdelJSON(), journalenhet1EntraIdJwt);
-    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
-    response =
-        patch("/saksmappe/" + saksmappeDTO.getId(), getSaksmappeJSON(), journalenhet1EntraIdJwt);
-    assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
-
-    // Should be able to delete as Journalenhet2 using Ansattporten Altinn2 JWT
-    response = delete("/saksmappe/" + saksmappeDTO.getId(), journalenhet2Altinn2Jwt);
+    // Should be able to delete as Journalenhet2 using Ansattporten Altinn 3 JWT
+    response = delete("/saksmappe/" + saksmappeDTO.getId(), journalenhet2Jwt);
     assertEquals(HttpStatus.OK, response.getStatusCode());
-
-    // Should be able to delete as Journalenhet2 using Ansattporten Altinn3 JWT
-    response = delete("/arkivdel/" + arkivdelDTO.getId(), journalenhet2Altinn3Jwt);
+    response = delete("/arkivdel/" + arkivdelDTO.getId(), journalenhet2Jwt);
     assertEquals(HttpStatus.OK, response.getStatusCode());
-
-    // Should be able to delete as Journalenhet2 using Ansattporten Entra ID JWT
-    response = delete("/arkiv/" + arkivDTO.getId(), journalenhet2EntraIdJwt);
+    response = delete("/arkiv/" + arkivDTO.getId(), journalenhet2Jwt);
     assertEquals(HttpStatus.OK, response.getStatusCode());
   }
 
@@ -244,6 +197,35 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
     assertNull(enhetRepository.findByOrgnummer(orgnummer));
   }
 
+  @Test
+  void shouldRejectTokensWithoutWriteAccessToEInnsyn() throws Exception {
+    assertRejected(
+        generateMockAltinn3Jwt(
+            journalenhetOrgnummer,
+            ansattportenIssuerUri,
+            "another-client",
+            TEST_RESOURCE,
+            List.of("write")));
+    assertRejected(
+        generateMockAltinn3Jwt(
+            journalenhetOrgnummer,
+            ansattportenIssuerUri,
+            TEST_CLIENT_ID,
+            "urn:altinn:resource:unrelated",
+            List.of("write")));
+    assertRejected(
+        generateMockAltinn3Jwt(
+            journalenhetOrgnummer,
+            ansattportenIssuerUri,
+            TEST_CLIENT_ID,
+            TEST_RESOURCE,
+            List.of("read")));
+  }
+
+  private void assertRejected(String jwt) throws Exception {
+    assertEquals(HttpStatus.UNAUTHORIZED, get("/me", jwt).getStatusCode());
+  }
+
   private static KeyPair generateTestRsaKeyPair() {
     try {
       var keyPairGenerator = KeyPairGenerator.getInstance("RSA");
@@ -254,58 +236,6 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
     }
   }
 
-  private String generateMockAltinn2Jwt(String orgnummer) throws Exception {
-    var now = Instant.now();
-    var expiryTimeSeconds = 3600L;
-
-    if (orgnummer == null) {
-      orgnummer = journalenhetOrgnummer;
-    }
-
-    var claimsSetBuilder =
-        new JWTClaimsSet.Builder()
-            // Ansattporten returns a random subject
-            .subject(IdGenerator.generateId("subject"))
-            .issuer(ansattportenIssuerUri)
-            .jwtID(UUID.randomUUID().toString())
-            .issueTime(Date.from(now))
-            .expirationTime(Date.from(now.plusSeconds(expiryTimeSeconds)));
-
-    // Add demo-authorization_details
-    claimsSetBuilder.claim(
-        "authorization_details",
-        List.of(
-            Map.of(
-                "resource",
-                "urn:altinn:resource:2480:40",
-                "type",
-                "ansattporten:altinn:service",
-                "resource_name",
-                "Demo Ansattporten Service",
-                "reportees",
-                List.of(
-                    Map.of(
-                        "Rights",
-                        List.of("Read", "ArchiveDelete", "ArchiveRead"),
-                        "Authority",
-                        "iso6523-actorid-upis",
-                        "ID",
-                        "0192:" + orgnummer,
-                        "Name",
-                        "DEMO ORG")))));
-
-    var signedJWT =
-        new SignedJWT(
-            new JWSHeader.Builder(JWSAlgorithm.RS256)
-                .type(JOSEObjectType.JWT)
-                .keyID(TEST_KEY_ID)
-                .build(),
-            claimsSetBuilder.build());
-
-    signedJWT.sign(new RSASSASigner(TEST_KEY_PAIR.getPrivate()));
-    return signedJWT.serialize();
-  }
-
   private String generateMockAltinn3Jwt(String orgnummer) throws Exception {
     if (orgnummer == null) {
       orgnummer = journalenhetOrgnummer;
@@ -314,6 +244,13 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
   }
 
   static String generateMockAltinn3Jwt(String orgnummer, String issuerUri) throws Exception {
+    return generateMockAltinn3Jwt(
+        orgnummer, issuerUri, TEST_CLIENT_ID, TEST_RESOURCE, List.of("write"));
+  }
+
+  private static String generateMockAltinn3Jwt(
+      String orgnummer, String issuerUri, String clientId, String resource, List<String> actions)
+      throws Exception {
     var now = Instant.now();
     var expiryTimeSeconds = 3600L;
 
@@ -322,6 +259,7 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
             // Ansattporten returns a random subject
             .subject(IdGenerator.generateId("subject"))
             .issuer(issuerUri)
+            .audience(clientId)
             .jwtID(UUID.randomUUID().toString())
             .issueTime(Date.from(now))
             .expirationTime(Date.from(now.plusSeconds(expiryTimeSeconds)));
@@ -332,7 +270,7 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
         List.of(
             Map.of(
                 "resource",
-                "urn:altinn:resource:einnsyn-api",
+                resource,
                 "type",
                 "ansattporten:altinn:resource",
                 "resource_name",
@@ -344,47 +282,10 @@ class AnsattportenAuthenticationTest extends EinnsynControllerTestBase {
                         Map.of("authority", "iso6523-actorid-upis", "ID", "0192:" + orgnummer),
                         "resource",
                         "einnsyn-api",
+                        "actions",
+                        actions,
                         "unit_type",
                         "AS")))));
-
-    var signedJWT =
-        new SignedJWT(
-            new JWSHeader.Builder(JWSAlgorithm.RS256)
-                .type(JOSEObjectType.JWT)
-                .keyID(TEST_KEY_ID)
-                .build(),
-            claimsSetBuilder.build());
-
-    signedJWT.sign(new RSASSASigner(TEST_KEY_PAIR.getPrivate()));
-    return signedJWT.serialize();
-  }
-
-  private String generateMockEntraIdJwt(String orgnummer) throws Exception {
-    var now = Instant.now();
-    var expiryTimeSeconds = 3600L;
-
-    if (orgnummer == null) {
-      orgnummer = journalenhetOrgnummer;
-    }
-
-    var claimsSetBuilder =
-        new JWTClaimsSet.Builder()
-            // Ansattporten returns a random subject
-            .subject(IdGenerator.generateId("subject"))
-            .issuer(ansattportenIssuerUri)
-            .jwtID(UUID.randomUUID().toString())
-            .issueTime(Date.from(now))
-            .expirationTime(Date.from(now.plusSeconds(expiryTimeSeconds)));
-
-    // Add authorization_details
-    claimsSetBuilder.claim(
-        "authorization_details",
-        List.of(
-            Map.of(
-                "type",
-                "ansattporten:orgno",
-                "orgno",
-                Map.of("authority", "iso6523-actorid-upis", "ID", "0192:" + orgnummer))));
 
     var signedJWT =
         new SignedJWT(


### PR DESCRIPTION
Signature and issuer checks only prove Ansattporten issued a token to *somebody*. We never checked it was issued to *us*, or for *our* Altinn resource — so any valid Ansattporten token granted write access to the named organisation's Enhet subtree.

Now enforced in `AnsattportenAuthenticationProvider`:
- `client_id` must match `ANSATTPORTEN_CLIENT_ID` (access tokens carry no `aud`)
- an `authorization_details` entry must name `ANSATTPORTEN_RESOURCE`, type
  `ansattporten:altinn:resource`
- at least one authorized party must yield an orgnummer — previously a token
  granting nothing still authenticated

Rejected tokens return no authentication, so the request is anonymous (401).

Also drops `ansattporten:orgno` (affiliation rather than delegation — the thing this change closes) and Altinn 2, which Ansattporten no longer advertises.
