### PR TITLE
feat: send eInnsyn user agent when downloading Dokumentobjekt (EIN-5024)

### DIFF
--- a/src/main/java/no/einnsyn/backend/entities/dokumentobjekt/DokumentobjektService.java
+++ b/src/main/java/no/einnsyn/backend/entities/dokumentobjekt/DokumentobjektService.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,6 +39,9 @@ public class DokumentobjektService extends ArkivBaseService<Dokumentobjekt, Doku
   private static final String DEFAULT_DOWNLOAD_FILE_NAME = "einnsyn-download";
   private static final int DOWNLOAD_CONNECT_TIMEOUT_MS = 10_000;
   private static final int DOWNLOAD_READ_TIMEOUT_MS = 30_000;
+
+  // Some sources allowlist this value, it is inherited from the legacy eInnsyn API.
+  private static final String DOWNLOAD_USER_AGENT = "eInnsyn";
 
   @Getter(onMethod_ = @Override)
   private final DokumentobjektRepository repository;
@@ -339,6 +343,7 @@ public class DokumentobjektService extends ArkivBaseService<Dokumentobjekt, Doku
     var proxyAddress = new InetSocketAddress(downloadProxyHost, downloadProxyPort);
     var httpProxy = new Proxy(Proxy.Type.HTTP, proxyAddress);
     var connection = (HttpURLConnection) sourceUri.toURL().openConnection(httpProxy);
+    connection.setRequestProperty(HttpHeaders.USER_AGENT, DOWNLOAD_USER_AGENT);
     connection.setConnectTimeout(DOWNLOAD_CONNECT_TIMEOUT_MS);
     connection.setReadTimeout(DOWNLOAD_READ_TIMEOUT_MS);
     connection.setInstanceFollowRedirects(true);

--- a/src/test/java/no/einnsyn/backend/entities/dokumentobjekt/DokumentobjektControllerTest.java
+++ b/src/test/java/no/einnsyn/backend/entities/dokumentobjekt/DokumentobjektControllerTest.java
@@ -148,6 +148,7 @@ class DokumentobjektControllerTest extends EinnsynControllerTestBase {
       assertEquals("GET", proxyRequest.method());
       assertEquals(SOURCE_URL, proxyRequest.target());
       assertEquals("example.com", proxyRequest.hostHeader());
+      assertEquals("eInnsyn", proxyRequest.userAgentHeader());
     }
   }
 
@@ -362,7 +363,8 @@ class DokumentobjektControllerTest extends EinnsynControllerTestBase {
               new ProxyRequest(
                   exchange.getRequestMethod(),
                   exchange.getRequestURI().toString(),
-                  exchange.getRequestHeaders().getFirst("Host")));
+                  exchange.getRequestHeaders().getFirst("Host"),
+                  exchange.getRequestHeaders().getFirst("User-Agent")));
 
           if (returnContentType != null) {
             exchange.getResponseHeaders().set("Content-Type", returnContentType);
@@ -401,5 +403,6 @@ class DokumentobjektControllerTest extends EinnsynControllerTestBase {
     }
   }
 
-  private record ProxyRequest(String method, String target, String hostHeader) {}
+  private record ProxyRequest(
+      String method, String target, String hostHeader, String userAgentHeader) {}
 }


### PR DESCRIPTION
Downloads went out with the JDK default user agent (Java/25.x), since HttpURLConnection was used without setting the header. The legacy eInnsyn API sends "eInnsyn" instead, and some sources allowlist that value, so match it here.